### PR TITLE
Geocaching.com template has changed - Need to update pycaching

### DIFF
--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -275,7 +275,7 @@ class Geocaching(object):
         hidden = cacheDetails.find("div", "minorCacheDetails").findAll("div")[1]
         location = soup.find(id="uxLatLon")
         state = soup.find("ul", "OldWarning")
-        found = soup.find("div", "FoundStatus").find('p')
+        found = soup.find("div", "FoundStatus")
         DandT = soup.find("div", "CacheStarLabels").findAll("img")
         size = soup.find("div", "CacheSize").find("img")
         attributesRaw = soup("div", "CacheDetailNavigationWidget")[1].findAll("img")


### PR DESCRIPTION
Hi there,

I was trying to use pycaching but it crashes.

```
276         location = soup.find(id="uxLatLon")
277         state = soup.find("ul", "OldWarning")
--> 278         found = soup.find("div", "StatusInformationWidget").find("img")
279         DandT = soup.find("div", "CacheStarImgs").findAll("img")
280         size = soup.find("div", "CacheSize").find("img")

AttributeError: 'NoneType' object has no attribute 'find'
```

It seems Groundspeak has changed their templates.
I will fork and pull a request to fix this ASAP.

Damien.
