### PR TITLE
Fixing hint decoding issue (encoding to utf8) + new unittest

### DIFF
--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -294,10 +294,10 @@ class Geocaching(object):
         size = " ".join(size.get("alt").split()[1:]).lower()
         attributesRaw = map(lambda e: e.get("src").split('/')[-1].split("-"), attributesRaw)
         attributes = {} # parse attributes by src to know yes/no
-        for name, appendix in attributesRaw:
+        for attribute_name, appendix in attributesRaw:
             if appendix.startswith("blank"):
                 continue
-            attributes[name] = appendix.startswith("yes")
+            attributes[attribute_name] = appendix.startswith("yes")
         summary = userContent[0].text.encode("ascii", "xmlcharrefreplace")
         description = userContent[1]
         hint = Util.rot13(hint.text.strip().encode('utf-8'))


### PR DESCRIPTION
Rot13 translation is working but data from the webrequest was not encoded using utf8.

```
Traceback (most recent call last):
  File "geocaching.py", line 390, in test_loadCache
    c = self.g.loadCache("GC4FRG5")
  File "geocaching.py", line 303, in loadCache
    hint = Util.rot13(hint.text.strip())
  File "/Users/driquet/git/pycaching/pycaching/util.py", line 84, in rot13
    return string.translate(text, Util.rot13codeTable)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/string.py", line 498, in translate
    return s.translate(table + s[:0])
UnicodeDecodeError: 'ascii' codec can't decode byte 0x80 in position 128: ordinal not in range(128)
```

I fixed this bug and also add a unittest to test this case (with hint containing non-ascii chars).
