### PR TITLE
Cache fetching

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -86,9 +86,9 @@ class Cache(object):
         "teamwork": "Teamwork Required",
         "thorn": "Thorns",
         "ticks": "Ticks",
-        "touristOK": "Tourist Friendly",
+        "touristok": "Tourist Friendly",
         "treeclimbing": "Tree Climbing",
-        "UV": "UV Light Required",
+        "uv": "UV Light Required",
         "wading": "May Require Wading",
         "water": "Drinking Water Nearby",
         "wheelchair": "Wheelchair Accessible",
@@ -326,7 +326,7 @@ class Cache(object):
 
         self._attributes = {}
         for name, allowed in attributes.items():
-            name = name.strip()
+            name = name.strip().lower()
             if name in self._possible_attributes:
                 self._attributes[name] = allowed
             else:

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -107,6 +107,7 @@ class Cache(object):
         "mega": "Mega-Event Cache",
         "giga": "Giga-Event Cache",
         "earthcache": "Earthcache",
+        "137": "Earthcache",
         "13": "Cache in Trash out Event",
         "11": "Webcam Cache",
         "4": "Virtual Cache",


### PR DESCRIPTION
I had some problems with the latest version, probably due to changes at geocaching.com

Earthcache threw an exception '137 not a valid cache type'. If I removed the old "earthcache" that threw the same exception so both are in there now. Tested against http://www.geocaching.com/geocache/GC5JQ55_granit

Abandoned Structure attribute was not detected for http://www.geocaching.com/geocache/GC4QGMZ_punkknackarkalendern-4-7-tribute-to-sid-vicious

It seems like both lower case image names and camel case images exists right now. To support both all attribute names are made lower case in this pull request.