### PR TITLE
Caches lacking favorites now works

### DIFF
--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -477,7 +477,10 @@ class Geocaching(object):
         c.summary = user_content[0].text
         c.description = str(user_content[1])
         c.hint = Util.rot13(hint.text.strip())
-        c.favorites = int(favorites.text)
+        if favorites is None:
+            c.favorites = 0
+        else:
+            c.favorites = int(favorites.text)
 
         logging.debug("Cache loaded: %r", c)
         return c


### PR DESCRIPTION
The issue seems to only be with event caches.

Tested with http://www.geocaching.com/geocache/GC5R0P3_sankt-goran-och-draken among others

