### PR TITLE
Caches with trackables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,27 @@ Load trackable details
         "\n\nDescription:\n", travelbug.description,
         "\n\nCurrent Location:\n", travelbug.loaction)
 
+
+Find all nearby caches with trackables in them
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Notice the ``limit`` in search function. It is because ``search()``
+returns a generator object, which would fetch the caches forever in case
+of simple loop.
+
+.. code:: python
+
+    from pycaching import Geocaching, Point
+
+    point = Point(56.25263, 15.26738)
+    geocaching = Geocaching()
+    geocaching.login("user", "pass")
+
+    for cache in geocaching.search(point, limit=50):
+        if len(cache.trackables) > 0:
+            print(cache.name)
+
+
 --------
 Appendix
 --------

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -131,7 +131,7 @@ class Cache(object):
 
     def __init__(self, wp, geocaching, *, name=None, cache_type=None, location=None, state=None,
                  found=None, size=None, difficulty=None, terrain=None, author=None, hidden=None,
-                 attributes=None, summary=None, description=None, hint=None, favorites=None, pm_only=None):
+                 attributes=None, summary=None, description=None, hint=None, favorites=None, pm_only=None, trackables=None):
         self.wp = wp
         self.geocaching = geocaching
         if name is not None:
@@ -166,6 +166,8 @@ class Cache(object):
             self.favorites = favorites
         if pm_only is not None:
             self.pm_only = pm_only
+        if trackables is not None:
+            self.trackables = trackables
 
     def __str__(self):
         return self.wp
@@ -397,3 +399,32 @@ class Cache(object):
     def inside_area(self, area):
         """Calculate if geocache is inside given area"""
         return area.inside_area(self.location)
+
+    @property
+    @lazy_loaded
+    def trackables(self):
+        if self.trackable_page is not None:
+            self._trackables = self._geocaching.load_trackable_list(self.trackable_page)
+            self.trackable_page = None
+        else:
+            self._trackables = []
+        return self._trackables
+
+    @trackables.setter
+    def trackables(self, trackables):
+        if type(trackables) is trackables.Trackable:
+            self._trackables = [trackables]
+        elif type(trackables) is not list:
+            raise ValueError("Passed object is not list")
+
+    @property
+    @lazy_loaded
+    def trackable_page(self):
+        return self._trackable_page
+
+    @trackable_page.setter
+    def trackable_page(self, trackable_page):
+        if type(trackable_page) is str or trackable_page is None:
+            self._trackable_page = trackable_page
+        else:
+            raise ValueError("Passed object is not string")

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -5,6 +5,7 @@ import datetime
 from pycaching.errors import ValueError
 from pycaching.point import Point
 from pycaching.util import Util
+from pycaching.trackable import Trackable
 
 
 def lazy_loaded(func):
@@ -131,7 +132,7 @@ class Cache(object):
 
     def __init__(self, wp, geocaching, *, name=None, cache_type=None, location=None, state=None,
                  found=None, size=None, difficulty=None, terrain=None, author=None, hidden=None,
-                 attributes=None, summary=None, description=None, hint=None, favorites=None, pm_only=None, trackables=None):
+                 attributes=None, summary=None, description=None, hint=None, favorites=None, pm_only=None, trackables=None, trackable_page=None):
         self.wp = wp
         self.geocaching = geocaching
         if name is not None:
@@ -168,6 +169,8 @@ class Cache(object):
             self.pm_only = pm_only
         if trackables is not None:
             self.trackables = trackables
+        if trackable_page is not None:
+            self.trackable_page = trackable_page
 
     def __str__(self):
         return self.wp
@@ -401,21 +404,26 @@ class Cache(object):
         return area.inside_area(self.location)
 
     @property
-    @lazy_loaded
     def trackables(self):
-        if self.trackable_page is not None:
-            self._trackables = self._geocaching.load_trackable_list(self.trackable_page)
-            self.trackable_page = None
-        else:
-            self._trackables = []
-        return self._trackables
+        try:
+            return self._trackables
+        except:
+            if self.trackable_page is not None:
+                logging.debug("Loading trackables from %s", self.trackable_page)
+                self._trackables = self._geocaching.load_trackable_list(self.trackable_page)
+                self.trackable_page = None
+            else:
+                self._trackables = []
+            return self._trackables
 
     @trackables.setter
     def trackables(self, trackables):
-        if type(trackables) is trackables.Trackable:
+        if type(trackables) is Trackable:
             self._trackables = [trackables]
         elif type(trackables) is not list:
             raise ValueError("Passed object is not list")
+        else:
+            self._trackables = trackables
 
     @property
     @lazy_loaded

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -38,6 +38,7 @@ class Geocaching(object):
         "login_page":       _baseurl + "login/default.aspx",
         "cache_details":    _baseurl + "geocache/{wp}",
         "trackable_details":_baseurl + "track/details.aspx?tracker={tid}",
+        "trackable_base":   _baseurl + "track/",
         "search":           _baseurl + "play/search",
         "search_more":      _baseurl + "play/search/more-results",
         "geocode":          _baseurl + "api/geocode",
@@ -454,6 +455,14 @@ class Geocaching(object):
         hint = root.find(id="div_hint")
         favorites = root.find("span", "favorite-value")
 
+        # check for trackables
+        inventory_raw = root.find_all("div", "CacheDetailNavigationWidget")
+        inventory_links = inventory_raw[1].find_all("a")
+        if len(inventory_links) >= 3:
+            trackable_page = self._urls['trackable_base'] + inventory_links[-3].get("href")
+        else:
+            trackable_page = None
+
         # create cache object
         c = destination or Cache(wp, self)
         assert isinstance(c, Cache)
@@ -478,7 +487,7 @@ class Geocaching(object):
             c.favorites = 0
         else:
             c.favorites = int(favorites.text)
-
+        c.trackable_page = trackable_page
         logging.debug("Cache loaded: %r", c)
         return c
 
@@ -564,3 +573,15 @@ class Geocaching(object):
             return login_page.soup.find("div", "LoggedIn").find("strong").text
         except AttributeError:
             return None
+
+    @login_needed
+    def load_trackable_list(self, url):
+        try:
+            root = self._browser.get(url).soup
+        except requests.exceptions.ConnectionError as e:
+            raise Error("Cannot load cache details page.") from e
+
+        trackable_table = root.find_all("table")[1]
+        links_raw = trackable_table.find_all("a")
+        urls = [l.get("href") for l in links_raw if "track" in l.get("href")]
+        return [self.load_trackable_by_url(t) for t in urls]

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -495,15 +495,7 @@ class Geocaching(object):
         return self.load_cache_by_url(url, destination)
 
     @login_needed
-    def load_trackable(self, tid):
-        """Loads details from trackable page.
-
-        Loads all trackable details and return fully populated trackable object."""
-
-        assert type(tid) is str and tid.startswith("TB")
-        logging.info("Loading details about %s...", tid)
-
-        url = self._urls["trackable_details"].format(tid=tid)
+    def load_trackable_by_url(self, url):
         try:
             root = self._browser.get(url).soup
         except requests.exceptions.ConnectionError as e:
@@ -548,6 +540,18 @@ class Geocaching(object):
         t.description = description
         t.goal = goal
         return t
+
+    @login_needed
+    def load_trackable(self, tid):
+        """Loads details from trackable page.
+
+        Loads all trackable details and return fully populated trackable object."""
+
+        assert type(tid) is str and tid.startswith("TB")
+        logging.info("Loading details about %s...", tid)
+
+        url = self._urls["trackable_details"].format(tid=tid)
+        return self.load_trackable_by_url(self, url)
 
     def get_logged_user(self, login_page=None):
         """Returns the name of curently logged user or None, if no user is logged in."""

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -6,16 +6,19 @@ from pycaching.errors import ValueError
 from pycaching import Cache
 from pycaching import Geocaching
 from pycaching import Point
+from pycaching import Trackable
 
 
 class TestProperties(unittest.TestCase):
 
     def setUp(self):
         self.gc = Geocaching()
+        self.t = Trackable("TB1234", self.gc, name="TrackMe")
         self.c = Cache("GC12345", self.gc, name="Testing", cache_type="Traditional Cache", location=Point(), state=True,
                        found=False, size="micro", difficulty=1.5, terrain=5, author="human", hidden=date(2000, 1, 1),
                        attributes={"onehour": True, "kids": False, "available": True}, summary="text",
-                       description="long text", hint="rot13", favorites=0, pm_only=False)
+                       description="long text", hint="rot13", favorites=0, pm_only=False,
+                       trackables=self.t)
 
     def test___str__(self):
         self.assertEqual(str(self.c), "GC12345")
@@ -129,3 +132,15 @@ class TestProperties(unittest.TestCase):
 
     def test_pm_only(self):
         self.assertEqual(self.c.pm_only, False)
+
+    def test_trackable_page(self):
+        with self.subTest("invalid url"):
+            with self.assertRaises(ValueError):
+                self.c.trackable_page = 7
+        with self.subTest("valid url"):
+            self.c.trackable_page = "https://www.geocaching.com"
+            self.assertEqual(self.c.trackable_page, "https://www.geocaching.com")
+
+    def test_trackables(self):
+        self.assertEqual(list, type(self.c.trackables))
+        self.assertEqual(Trackable, type(self.c.trackables[0]))


### PR DESCRIPTION
The cache object now stores info about the trackables it contains. If the cache has trackables, the url to the list of those trackables is stored and when the user tries to access the trackables-property the actual list is loaded. This to reduce time loading caches for "normal" use.

New example use added. (Listing nearby caches that contain trackables.)