### PR TITLE
Quickloaded trackables

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -132,7 +132,7 @@ class Cache(object):
 
     def __init__(self, wp, geocaching, *, name=None, cache_type=None, location=None, state=None,
                  found=None, size=None, difficulty=None, terrain=None, author=None, hidden=None,
-                 attributes=None, summary=None, description=None, hint=None, favorites=None, pm_only=None, trackables=None, trackable_page=None):
+                 attributes=None, summary=None, description=None, hint=None, favorites=None, pm_only=None, trackables=None):
         self.wp = wp
         self.geocaching = geocaching
         if name is not None:
@@ -169,8 +169,6 @@ class Cache(object):
             self.pm_only = pm_only
         if trackables is not None:
             self.trackables = trackables
-        if trackable_page is not None:
-            self.trackable_page = trackable_page
 
     def __str__(self):
         return self.wp
@@ -404,17 +402,9 @@ class Cache(object):
         return area.inside_area(self.location)
 
     @property
+    @lazy_loaded
     def trackables(self):
-        try:
-            return self._trackables
-        except:
-            if self.trackable_page is not None:
-                logging.debug("Loading trackables from %s", self.trackable_page)
-                self._trackables = self._geocaching.load_trackable_list(self.trackable_page)
-                self.trackable_page = None
-            else:
-                self._trackables = []
-            return self._trackables
+        return self._trackables
 
     @trackables.setter
     def trackables(self, trackables):
@@ -424,15 +414,3 @@ class Cache(object):
             raise ValueError("Passed object is not list")
         else:
             self._trackables = trackables
-
-    @property
-    @lazy_loaded
-    def trackable_page(self):
-        return self._trackable_page
-
-    @trackable_page.setter
-    def trackable_page(self, trackable_page):
-        if type(trackable_page) is str or trackable_page is None:
-            self._trackable_page = trackable_page
-        else:
-            raise ValueError("Passed object is not string")

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -563,7 +563,7 @@ class Geocaching(object):
         logging.info("Loading details about %s...", tid)
 
         url = self._urls["trackable_details"].format(tid=tid)
-        return self.load_trackable_by_url(self, url, destination)
+        return self.load_trackable_by_url(url, destination)
 
     def get_logged_user(self, login_page=None):
         """Returns the name of curently logged user or None, if no user is logged in."""

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -585,9 +585,12 @@ class Geocaching(object):
             raise Error("Cannot load cache details page.") from e
 
         trackable_table = root.find_all("table")[1]
-        links_raw = trackable_table.find_all("a")
-        urls = [l.get("href") for l in links_raw if "track" in l.get("href")]
-        names = [re.split("[\<\>]", str(l))[2] for l in links_raw if "track" in l.get("href")]
+        urls_raw = trackable_table.find_all("a")
+        # filter out all urls for trackables
+        urls = [url.get("href") for url in urls_raw if "track" in url.get("href")]
+        # find the names matching the trackble urls
+        names = [re.split("[\<\>]", str(url))[2] for url in urls_raw if "track" in url.get("href")]
+        # create trackables and build list to return
         trackables = []
         for n, u in zip(names, urls):
             trackables.append(Trackable(None, self, name=n, trackable_page=u))

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -487,7 +487,10 @@ class Geocaching(object):
             c.favorites = 0
         else:
             c.favorites = int(favorites.text)
-        c.trackable_page = trackable_page
+        if trackable_page is not None:
+            c.trackables = self.load_trackable_list(trackable_page)
+        else:
+            c.trackables = []
         logging.debug("Cache loaded: %r", c)
         return c
 
@@ -584,4 +587,8 @@ class Geocaching(object):
         trackable_table = root.find_all("table")[1]
         links_raw = trackable_table.find_all("a")
         urls = [l.get("href") for l in links_raw if "track" in l.get("href")]
-        return [self.load_trackable_by_url(t) for t in urls]
+        names = [re.split("[\<\>]", str(l))[2] for l in links_raw if "track" in l.get("href")]
+        trackables = []
+        for n, u in zip(names, urls):
+            trackables.append(Trackable(None, self, name=n, trackable_page=u))
+        return trackables

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -504,7 +504,7 @@ class Geocaching(object):
         return self.load_cache_by_url(url, destination)
 
     @login_needed
-    def load_trackable_by_url(self, url):
+    def load_trackable_by_url(self, url, destination=None):
         try:
             root = self._browser.get(url).soup
         except requests.exceptions.ConnectionError as e:
@@ -539,9 +539,9 @@ class Geocaching(object):
         goal = goal_raw[0].text
 
         # create trackable object
-        t = Trackable(tid, self)
+        t = destination or Trackable(tid, self)
         assert isinstance(t, Trackable)
-        t = Trackable(tid, self)
+        t.tid = tid
         t.name = name
         t.owner = owner
         t.location = location
@@ -551,7 +551,7 @@ class Geocaching(object):
         return t
 
     @login_needed
-    def load_trackable(self, tid):
+    def load_trackable(self, tid, destination=None):
         """Loads details from trackable page.
 
         Loads all trackable details and return fully populated trackable object."""
@@ -560,7 +560,7 @@ class Geocaching(object):
         logging.info("Loading details about %s...", tid)
 
         url = self._urls["trackable_details"].format(tid=tid)
-        return self.load_trackable_by_url(self, url)
+        return self.load_trackable_by_url(self, url, destination)
 
     def get_logged_user(self, login_page=None):
         """Returns the name of curently logged user or None, if no user is logged in."""

--- a/pycaching/trackable.py
+++ b/pycaching/trackable.py
@@ -17,7 +17,10 @@ def lazy_loaded(func):
             return func(*args, **kwargs)
         except AttributeError:
             logging.debug("Lazy loading: %s", func.__name__)
-            self.geocaching.load_trackable(self.tid, self)
+            try:
+                self.geocaching.load_trackable_by_url(self.trackable_page, self)
+            except AttributeError:
+                self.geocaching.load_trackable(self.tid, self)
             return func(*args, **kwargs)
 
     return wrapper
@@ -26,7 +29,7 @@ def lazy_loaded(func):
 class Trackable(object):
 
     def __init__(self, tid, geocaching, *, name=None, location=None, owner=None,
-                 type=None, description=None, goal=None):
+                 type=None, description=None, goal=None, trackable_page=None):
         if geocaching is not None:
            self.geocaching = geocaching
         else:
@@ -47,6 +50,8 @@ class Trackable(object):
             self.type = type
         if description is not None:
             self.description = description
+        if trackable_page is not None:
+            self.trackable_page = trackable_page
 
     def __str__(self):
         return self.tid
@@ -55,6 +60,7 @@ class Trackable(object):
         return self.tid == other.tid
 
     @property
+    @lazy_loaded
     def tid(self):
         return self._tid
 

--- a/pycaching/trackable.py
+++ b/pycaching/trackable.py
@@ -3,6 +3,7 @@
 import logging
 import datetime
 from pycaching.errors import ValueError
+from pycaching.errors import LoadError
 from pycaching.point import Point
 from pycaching.util import Util
 
@@ -17,10 +18,13 @@ def lazy_loaded(func):
             return func(*args, **kwargs)
         except AttributeError:
             logging.debug("Lazy loading: %s", func.__name__)
-            try:
+            if hasattr(self, 'trackable_page'):
                 self.geocaching.load_trackable_by_url(self.trackable_page, self)
-            except AttributeError:
+            elif hasattr(self, '_tid'):
                 self.geocaching.load_trackable(self.tid, self)
+            else:
+                raise LoadError("Trackable lacks info for lazy loading")
+
             return func(*args, **kwargs)
 
     return wrapper

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -133,14 +133,6 @@ class TestProperties(unittest.TestCase):
     def test_pm_only(self):
         self.assertEqual(self.c.pm_only, False)
 
-    def test_trackable_page(self):
-        with self.subTest("invalid url"):
-            with self.assertRaises(ValueError):
-                self.c.trackable_page = 7
-        with self.subTest("valid url"):
-            self.c.trackable_page = "https://www.geocaching.com"
-            self.assertEqual(self.c.trackable_page, "https://www.geocaching.com")
-
     def test_trackables(self):
         self.assertEqual(list, type(self.c.trackables))
         self.assertEqual(Trackable, type(self.c.trackables[0]))

--- a/test/test_geocaching.py
+++ b/test/test_geocaching.py
@@ -9,6 +9,7 @@ from pycaching import Geocaching
 from pycaching import Cache
 from pycaching import Point
 from pycaching import Rectangle
+from pycaching import Trackable
 
 
 # please DO NOT CHANGE!
@@ -196,6 +197,16 @@ class TestLoading(unittest.TestCase):
         self.assertTrue(isinstance(cache, Cache))
         self.assertEqual("GC4808G", cache.wp)
 
+    def test_load_trackable(self):
+        trackable = self.g.load_trackable("TB1KEZ9")
+        self.assertTrue(isinstance(trackable, Trackable))
+        self.assertEqual("TB1KEZ9", trackable.tid)
+
+    def test_load_trackable_list(self):
+        test_url = "http://www.geocaching.com/track/search.aspx?wid=24fac98c-5332-4caa-a4c8-369fae530211&ccid=866132"
+        trackable_list = self.g.load_trackable_list(test_url)
+        self.assertTrue(isinstance(trackable_list, list))
+
     @classmethod
     def tearDownClass(cls):
         cls.g.logout()
@@ -216,6 +227,21 @@ class TestLazyLoading(unittest.TestCase):
         with self.subTest("non-ascii chars"):
             cache = Cache("GC4FRG5", self.g)
             self.assertEqual("Entre l'arbre et la grille.", cache.hint)
+
+    def test_load_trackable(self):
+        with self.subTest("tid"):
+            trackable = Trackable("TB1KEZ9", self.g)
+            self.assertEqual("Lilagul #2: SwedenHawk Geocoin", trackable.name)
+
+        with self.subTest("trackable url"):
+            url = "http://www.geocaching.com/track/details.aspx?guid=cff00ac4-f562-486e-b303-32b2d01ed386"
+            trackable = Trackable(None, self.g, trackable_page=url)
+            self.assertEqual("Lilagul #2: SwedenHawk Geocoin", trackable.name)
+
+        with self.subTest("fail lazyload"):
+            trackable = Trackable(None, self.g)
+            with(self.assertRaises(pycaching.errors.LoadError)):
+                trackable.name 
 
     @classmethod
     def tearDownClass(cls):

--- a/test/test_trackable.py
+++ b/test/test_trackable.py
@@ -12,7 +12,7 @@ class TestProperties(unittest.TestCase):
 
     def setUp(self):
         self.gc = Geocaching()
-        self.t = Trackable("TB123AB", self.gc, name="Testing", type="Travel Bug", location=Point(), owner="human", description="long text")
+        self.t = Trackable("TB123AB", self.gc, name="Testing", type="Travel Bug", location=Point(), owner="human", description="long text", goal="short text")
 
     def test___str__(self):
         self.assertEqual(str(self.t), "TB123AB")
@@ -42,3 +42,6 @@ class TestProperties(unittest.TestCase):
 
     def test_description(self):
         self.assertEqual(self.t.description, "long text")
+
+    def test_goal(self):
+        self.assertEqual(self.t.goal, "short text")


### PR DESCRIPTION
This is a bit of a cleanup making the trackable handling a bit more inline with the rest of the pycaching module and reduces clutter in the Cache class. Now when loading the cache the trackable page is parsed and trackables are quick-loaded.
(Previously trackables were not loaded at all when parsing a cache, instead a link to the trackable search page for the cache was stored and loaded together with all trackables when the trackable property was requested.)

