### PR TITLE
Added logbook loading for caches.

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -110,7 +110,7 @@ class Cache(object):
     def __init__(self, wp, geocaching, *, name=None, type=None, location=None, state=None,
                  found=None, size=None, difficulty=None, terrain=None, author=None, hidden=None,
                  attributes=None, summary=None, description=None, hint=None, favorites=None,
-                 pm_only=None, trackables=None, url=None):
+                 pm_only=None, trackables=None, url=None, logbook=None):
         self.geocaching = geocaching
         if wp is not None:
             self.wp = wp
@@ -150,6 +150,8 @@ class Cache(object):
             self.trackables = trackables
         if url is not None:
             self.url = url
+        if logbook is not None:
+            self.logbook = logbook
 
     def __str__(self):
         return self.wp
@@ -369,3 +371,12 @@ class Cache(object):
         elif _type(trackables) is not list:
             raise ValueError("Passed object is not list")
         self._trackables = trackables
+
+    @property
+    @lazy_loaded
+    def logbook(self):
+        return self._logbook
+
+    @logbook.setter
+    def logbook(self, logbook):
+        self._logbook = logbook

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -46,6 +46,7 @@ class Geocaching(object):
         "map":               _tile_url + "map.details",
         "tile":              _tile_url + "map.png",
         "grid":              _tile_url + "map.info",
+        "logs":              _baseurl + "seek/geocache.logbook"
     }
 
     def __init__(self):
@@ -426,12 +427,26 @@ class Geocaching(object):
         return c
 
     @login_needed
+    def load_logbook(self, userToken, num=10):
+        url = self._urls['logs']
+        payload = {
+                "tkn" : userToken,
+                "idx" : "1",
+                "num" : num,
+                "decrypt" : "true"
+                }
+        try:
+            log_json = self._browser.get(url, params=payload).json()
+        except requests.exceptions.ConnectionError as e:
+            raise Error("Cannot load log page.") from e
+        return log_json['data']
+
+    @login_needed
     def load_cache_by_url(self, url, destination=None):
         try:
             root = self._browser.get(url).soup
         except requests.exceptions.ConnectionError as e:
             raise Error("Cannot load cache details page.") from e
-
         cache_details = root.find(id="cacheDetails")
 
         # check for PM only caches if using free account
@@ -456,6 +471,12 @@ class Geocaching(object):
         hint = root.find(id="div_hint")
         favorites = root.find("span", "favorite-value")
 
+        # load log
+        num_logs = root.find_all('div', 'InformationWidget Clear')[0]
+        num_logs = num_logs.find_all('h3')[0].get_text().strip()
+        num_logs = num_logs.split(' ')[0]
+        userToken =  re.findall("userToken\\s*=\\s*'([^']+)'", str(root))[0]
+        logs = self.load_logbook(userToken, num_logs)
         # check for trackables
         inventory_raw = root.find_all("div", "CacheDetailNavigationWidget")
         inventory_links = inventory_raw[1].find_all("a")
@@ -493,6 +514,8 @@ class Geocaching(object):
             c.trackables = self.load_trackable_list(trackable_page)
         else:
             c.trackables = []
+        c.logbook = logs
+
         logging.debug("Cache loaded: %r", c)
         return c
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -19,7 +19,7 @@ class TestProperties(unittest.TestCase):
                        found=False, size=Size.micro, difficulty=1.5, terrain=5, author="human", hidden=date(2000, 1, 1),
                        attributes={"onehour": True, "kids": False, "available": True}, summary="text",
                        description="long text", hint="rot13", favorites=0, pm_only=False,
-                       trackables=self.t)
+                       trackables=self.t, logbook=[])
 
     def test___str__(self):
         self.assertEqual(str(self.c), "GC12345")
@@ -137,3 +137,6 @@ class TestProperties(unittest.TestCase):
     def test_trackables(self):
         self.assertEqual(list, type(self.c.trackables))
         self.assertEqual(Trackable, type(self.c.trackables[0]))
+
+    def test_logbook(self):
+        self.assertEqual(list, type(self.c.logbook))


### PR DESCRIPTION
* Geocaching class extended with load_logbook() method.
* Cache class extended with getter and setter for logbook member
* Basic test for logbook getter added

This should resolve #30. The logbook is right now always loaded when the cache is loaded, this can easily be changed to be loaded only when the log is accessed by storing the userToken in the cache instead of reading the log directly.

The code for reading the number of logs to request is a bit ugly and any suggestion of improvement is appreciated.