### PR TITLE
Corrected typo preventing loading cache from url

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -373,7 +373,7 @@ class Cache(object):
     def load(self):
         # pick url based on what info we have right now
         if hasattr(self, "url"):
-            root = self.geocaching._request(url)
+            root = self.geocaching._request(self.url)
         elif hasattr(self, "_wp"):
             root = self.geocaching._request("seek/cache_details.aspx", params={"wp": self._wp})
         else:


### PR DESCRIPTION
When trying to reproduce this issue I tried loading an archived event that I'd logged as attended for tests. Archived caches aren't search-able and thus normal loading failed. When setting the url manually I got NameError. This pull request fixes that small issue.
