### PR TITLE
Post log tests

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -566,7 +566,7 @@ class Cache(object):
         return (valid_types, hidden_elements)
 
     def post_log(self, l):
-        if len(l.text) == 0:
+        if not l.text:
             raise errors.ValueError("Log text is empty")
 
         valid_types, hidden = self._load_log_page()

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -556,6 +556,9 @@ class Cache(object):
             yield t
 
     def post_log(self, l):
+        if len(l.text) == 0:
+            raise errors.ValueError("Log text is empty")
+
         log_page = self.geocaching._request(self.log_page_url)
         # Find all valid log types for the cache
         type_options = log_page.find_all("option")

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -19,7 +19,8 @@ class TestProperties(unittest.TestCase):
         self.c = Cache(self.gc, "GC12345", name="Testing", type=Type.traditional, location=Point(), state=True,
                        found=False, size=Size.micro, difficulty=1.5, terrain=5, author="human", hidden=date(2000, 1, 1),
                        attributes={"onehour": True, "kids": False, "available": True}, summary="text",
-                       description="long text", hint="rot13", favorites=0, pm_only=False)
+                       description="long text", hint="rot13", favorites=0, pm_only=False,
+                       log_page_url="/seek/log.aspx?ID=1234567&lcn=1")
 
     def test___str__(self):
         self.assertEqual(str(self.c), "GC12345")
@@ -134,6 +135,8 @@ class TestProperties(unittest.TestCase):
     def test_pm_only(self):
         self.assertEqual(self.c.pm_only, False)
 
+    def test_log_page_url(self):
+        self.assertEqual(self.c.log_page_url, "/seek/log.aspx?ID=1234567&lcn=1")
 
 class TestMethods(unittest.TestCase):
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -3,11 +3,12 @@
 import unittest
 from datetime import date
 from pycaching.errors import ValueError
-from pycaching.enums import Type, Size
+from pycaching.enums import Type, Size, LogType
 from pycaching import Cache
 from pycaching import Geocaching
 from pycaching import Point
 from pycaching import Trackable
+from pycaching import Log
 
 from test.test_geocaching import _username, _password
 
@@ -137,6 +138,23 @@ class TestProperties(unittest.TestCase):
 
     def test_log_page_url(self):
         self.assertEqual(self.c.log_page_url, "/seek/log.aspx?ID=1234567&lcn=1")
+
+    def test_post_log(self):
+        def mock_request(self, url, *, expect="soup", method="GET", login_check=True, **kwargs):
+            class mocked_soup():
+                def find_all(*args):
+                    return {}
+            return mocked_soup()
+
+        real_request = Geocaching._request
+        Geocaching._request = mock_request
+
+        with self.subTest("empty log text"):
+            l = Log(text="", visited=date.today(), type = LogType.note)
+            with self.assertRaises(ValueError):
+                self.c.post_log(l)
+
+        Geocaching._request = real_request
 
 class TestMethods(unittest.TestCase):
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -155,11 +155,12 @@ class TestProperties(unittest.TestCase):
         real_load_log_page = Cache._load_log_page
         Cache._load_log_page = mock_load_log_page
 
-        with self.subTest("log type"):
+        with self.subTest("invalid log type"):
             l = Log(text="Test log.", visited=date.today(), type = LogType.found_it)
             with self.assertRaises(ValueError):
                 self.c.post_log(l)
 
+        with self.subTest("valid log type"):
             l = Log(text="Test log.", visited=date.today(), type = LogType.didnt_find_it)
             self.c.post_log(l)
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -146,8 +146,22 @@ class TestProperties(unittest.TestCase):
                     return {}
             return mocked_soup()
 
+        def mock_load_log_page(self):
+            return ({'temporarily disable listing': '22', 'archive': '5', 'write note': '4', "didn't find it": '3', '- select type of log -': '-1', 'update coordinates': '47', 'needs maintenance': '45', 'owner maintenance': '46'}, {})
+
         real_request = Geocaching._request
         Geocaching._request = mock_request
+
+        real_load_log_page = Cache._load_log_page
+        Cache._load_log_page = mock_load_log_page
+
+        with self.subTest("log type"):
+            l = Log(text="Test log.", visited=date.today(), type = LogType.found_it)
+            with self.assertRaises(ValueError):
+                self.c.post_log(l)
+
+            l = Log(text="Test log.", visited=date.today(), type = LogType.didnt_find_it)
+            self.c.post_log(l)
 
         with self.subTest("empty log text"):
             l = Log(text="", visited=date.today(), type = LogType.note)
@@ -155,6 +169,7 @@ class TestProperties(unittest.TestCase):
                 self.c.post_log(l)
 
         Geocaching._request = real_request
+        Cache._load_log_page = real_load_log_page
 
 class TestMethods(unittest.TestCase):
 


### PR DESCRIPTION
This adds some tests related to post_log().

09e0409 is simple enough, just tests the property ```log_page_url```
e7a19f4 verifies that the log text field is not an empty string. The small change in ```pycaching/cache.py``` should be added even if the test is a bit clumsy.
8f2adef is a test for the log-type matching code and might be overkill since it requires some restructuring, mocks out a lot and is generally messy.