### PR TITLE
Sets pm_only status correctly for premium members

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -561,6 +561,8 @@ class Cache(object):
             raise errors.PMOnlyException()
 
         # details not avaliable for basic members for PM only caches ------------------------------
+        pm_only_warning = root.find("p", "Warning NoBottomSpacing")
+        self.pm_only = pm_only_warning and ("Premium Member Only" in pm_only_warning.text) or False
 
         attributes_widget, inventory_widget, *_ = root.find_all("div", "CacheDetailNavigationWidget")
 


### PR DESCRIPTION
Premium members can now see if a cache is only available for premium members.

Can be useful to know even if it won't affect loading the cache. For example if you're compiling a list for a geocaching trip and all members aren't premium.