### PR TITLE
Mystery original coords

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -594,7 +594,7 @@ class Cache(object):
 
         self.location = Point.from_string(root.find(id="uxLatLon").text)
 
-        #find original location if any
+        # find original location if any
         scripts = [s.text for s in root.find_all("script") if "oldLatLng\":" in s.text] or None
         if scripts and len(scripts) > 0:
             old_lat_long = scripts[0].split("oldLatLng\":")[1].split(']')[0].split('[')[1]

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -233,7 +233,7 @@ class Cache(object):
     def original_location(self, original_location):
         if _type(original_location) is str:
             original_location = Point.from_string(original_location)
-        elif _type(original_location) is not Point:
+        elif _type(original_location) is not Point and original_location is not None:
             raise errors.ValueError(
                 "Passed object is not Point instance nor string containing coordinates.")
         self._original_location = original_location
@@ -622,6 +622,8 @@ class Cache(object):
         if "oldLatLng\":" in js_content:
             old_lat_long = js_content.split("oldLatLng\":")[1].split(']')[0].split('[')[1]
             self.original_location = Point(old_lat_long)
+        else:
+            self.original_location = None
 
         # if there are some trackables
         if len(inventory_widget.find_all("a")) >= 3:

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -594,12 +594,6 @@ class Cache(object):
 
         self.location = Point.from_string(root.find(id="uxLatLon").text)
 
-        # find original location if any
-        scripts = [s.text for s in root.find_all("script") if "oldLatLng\":" in s.text] or None
-        if scripts and len(scripts) > 0:
-            old_lat_long = scripts[0].split("oldLatLng\":")[1].split(']')[0].split('[')[1]
-            self.original_location = Point(old_lat_long)
-
         self.state = root.find("ul", "OldWarning") is None
 
         found = root.find("div", "FoundStatus")
@@ -624,6 +618,10 @@ class Cache(object):
 
         js_content = "\n".join(map(lambda i: i.text, root.find_all("script")))
         self._logbook_token = re.findall("userToken\\s*=\\s*'([^']+)'", js_content)[0]
+        # find original location if any
+        if "oldLatLng\":" in js_content:
+            old_lat_long = js_content.split("oldLatLng\":")[1].split(']')[0].split('[')[1]
+            self.original_location = Point(old_lat_long)
 
         # if there are some trackables
         if len(inventory_widget.find_all("a")) >= 3:

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -72,13 +72,16 @@ class TestProperties(unittest.TestCase):
             self.assertEqual(self.c.original_location,
                              Point.from_string("S 36 51.918 E 174 46.725"))
 
+        with self.subTest("None type"):
+            self.c.original_location = None
+
         with self.subTest("filter invalid string"):
             with self.assertRaises(PycachingValueError):
                 self.c.original_location = "somewhere"
 
         with self.subTest("filter invalid types"):
             with self.assertRaises(PycachingValueError):
-                self.c.original_location = None
+                self.c.original_location = 123
 
     def test_state(self):
         self.assertEqual(self.c.state, True)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -20,7 +20,7 @@ class TestProperties(unittest.TestCase):
                        found=False, size=Size.micro, difficulty=1.5, terrain=5, author="human", hidden=date(2000, 1, 1),
                        attributes={"onehour": True, "kids": False, "available": True}, summary="text",
                        description="long text", hint="rot13", favorites=0, pm_only=False,
-                       _log_page_url="/seek/log.aspx?ID=1234567&lcn=1")
+                       _log_page_url="/seek/log.aspx?ID=1234567&lcn=1", original_location=Point())
 
     def test___str__(self):
         self.assertEqual(str(self.c), "GC12345")
@@ -63,6 +63,22 @@ class TestProperties(unittest.TestCase):
         with self.subTest("filter invalid types"):
             with self.assertRaises(PycachingValueError):
                 self.c.location = None
+
+    def test_original_location(self):
+        self.assertEqual(self.c.original_location, Point())
+
+        with self.subTest("automatic str conversion"):
+            self.c.original_location = "S 36 51.918 E 174 46.725"
+            self.assertEqual(self.c.original_location,
+                             Point.from_string("S 36 51.918 E 174 46.725"))
+
+        with self.subTest("filter invalid string"):
+            with self.assertRaises(PycachingValueError):
+                self.c.original_location = "somewhere"
+
+        with self.subTest("filter invalid types"):
+            with self.assertRaises(PycachingValueError):
+                self.c.original_location = None
 
     def test_state(self):
         self.assertEqual(self.c.state, True)


### PR DESCRIPTION
The simple solution for #37. A new property ```orginal_location``` is added to the Cache-object.

As I implemented this I started thinking that this might not be the best way, maybe we should intruduce a dictionary named additional_locations which contains any additional coordinates. Since many caches have extra locations such as coordinates for parking or for the different steps in a multi-cache.

Any thoughts?