### PR TITLE
Fix failing load non-existing cache test

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -560,8 +560,10 @@ class Cache(object):
             self.favorites = int(details[11])
         else:
             # parse from <title> - get first word
-            self.wp = root.title.string.split(" ")[0]
-
+            try:
+                self.wp = root.title.string.split(" ")[0]
+            except:
+                raise errors.LoadError
             self.name = cache_details.find("h2").text
 
             self.author = cache_details("a")[1].text


### PR DESCRIPTION
Loading a non-existing cache returns a 404-page and will raise a ValueError when the GC-code is determined. To fix this the ValueError is caught and the expected LoadError is raised.

This popped up as an issue when I tried to get the tests for my other pull-request running.