### PR TITLE
Catch exception if waypoint location is invalid

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -840,7 +840,13 @@ class Waypoint():
                 columns = r1.find_all("td") + r2.find_all("td")
                 identifier = columns[4].text.strip()
                 type = columns[2].find("img").get("title")
-                loc = Point(columns[6].text.strip())
+                location_string = columns[6].text.strip()
+                try:
+                    loc = Point(location_string)
+                except ValueError:
+                    loc = None
+                    logging.debug("No valid location format in waypoint %s: %s"
+                        % (identifier, location_string))
                 note = columns[10].text.strip()
                 waypoints_dict[identifier] = cls(identifier, type, loc, note)
         return waypoints_dict

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -845,8 +845,8 @@ class Waypoint():
                     loc = Point(location_string)
                 except ValueError:
                     loc = None
-                    logging.debug("No valid location format in waypoint %s: %s"
-                                  % (identifier, location_string))
+                    logging.debug("No valid location format in waypoint {}: {}".format(
+                        identifier, location_string))
                 note = columns[10].text.strip()
                 waypoints_dict[identifier] = cls(identifier, type, loc, note)
         return waypoints_dict

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -846,7 +846,7 @@ class Waypoint():
                 except ValueError:
                     loc = None
                     logging.debug("No valid location format in waypoint %s: %s"
-                        % (identifier, location_string))
+                                  % (identifier, location_string))
                 note = columns[10].text.strip()
                 waypoints_dict[identifier] = cls(identifier, type, loc, note)
         return waypoints_dict


### PR DESCRIPTION
When parsing waypoints from the HTML table it is not guaranteed that the location is in proper format, e.g. hidden stages have '???' in the location field (see e.g. GC3WTTZ). This caused an unhandled exception in `Waypoint.from_html()`.

Fixing this issue by catching the `ValueError` raised by the `geopy.Point()` initializer and setting the waypoints location to `None`.