### PR TITLE
Issue29 cache loading by GUID

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -700,14 +700,14 @@ class Cache(object):
             self._load_guid()
         res = self.geocaching._request(self._urls["print_page"],
                                        params={"guid": self.guid})
-        if res.find("p", {"class": "Warning"}) is not None:
+        if res.find("p", "Warning") is not None:
             raise errors.PMOnlyException()
         content = res.find(id="Content")
 
         self.name = content.find("h2").text
 
         self.location = Point.from_string(
-            content.find("p", {"class": "LatLong Meta"}).text)
+            content.find("p", "LatLong Meta").text)
 
         type_img = os.path.basename(content.find("img").get("src"))
         self.type = Type.from_filename(os.path.splitext(type_img)[0])
@@ -715,8 +715,7 @@ class Cache(object):
         size_img = content.find("img", src=re.compile("\/icons\/container\/"))
         self.size = Size.from_string(size_img.get("alt").split(": ")[1])
 
-        D_and_T_img = content.find(
-            "p", {"class": "Meta DiffTerr"}).find_all("img")
+        D_and_T_img = content.find("p", "Meta DiffTerr").find_all("img")
         self.difficulty, self.terrain = [
             float(img.get("alt").split()[0]) for img in D_and_T_img
         ]

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -724,8 +724,8 @@ class Cache(object):
         self.author = content.find(
             "p", text=re.compile("Placed by:")).text.split("\r\n")[2].strip()
 
-        self.hidden = content.find(
-            "p", text=re.compile("Placed Date:")).text.split(": ")[1]
+        hidden_p = content.find("p", text=re.compile("Placed Date:"))
+        self.hidden = hidden_p.text.replace("Placed Date:", "").strip()
 
         attr_img = content.find_all("img", src=re.compile("\/attributes\/"))
         attributes_raw = [

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -729,7 +729,7 @@ class Cache(object):
 
         attr_img = content.find_all("img", src=re.compile("\/attributes\/"))
         attributes_raw = [
-            _.get("src").split("/")[-1].rsplit("-", 1) for _ in attr_img
+            os.path.basename(_.get("src")).rsplit("-", 1) for _ in attr_img
         ]
         self.attributes = {
             name: appendix.startswith("yes") for name, appendix

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -704,7 +704,7 @@ class Cache(object):
             raise errors.PMOnlyException()
         content = res.find(id="Content")
 
-        self.name = content.find("h2").get_text()
+        self.name = content.find("h2").text
 
         self.location = Point.from_string(
             content.find("p", {"class": "LatLong Meta"}).text)

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -185,7 +185,7 @@ class Cache(object):
 
         :type: :class:`str`
         """
-        return self._guid
+        return getattr(self, "_guid", None)
 
     @guid.setter
     def guid(self, guid):
@@ -713,8 +713,11 @@ class Cache(object):
 
         :raise .PMOnlyException: If the PM only warning is shown on the page
         """
-        if not hasattr(self, "guid"):
+        # If GUID has not yet been set, load it using the "tiles_server"
+        # utilizing `load_quick()`
+        if not self.guid:
             self.load_quick()
+
         res = self.geocaching._request(self._urls["print_page"],
                                        params={"guid": self.guid})
         if res.find("p", "Warning") is not None:

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -709,7 +709,7 @@ class Cache(object):
         self.location = Point.from_string(
             content.find("p", {"class": "LatLong Meta"}).text)
 
-        type_img = os.path.basename(content.find("h2").img.get("src"))
+        type_img = os.path.basename(content.find("img").get("src"))
         self.type = Type.from_filename(os.path.splitext(type_img)[0])
 
         size_img = content.find("img", src=re.compile("\/icons\/container\/"))

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -742,7 +742,7 @@ class Cache(object):
         self.description = content.find(
             "h2", text="Long Description").find_next("div").text
 
-        self.hint = rot13(content.find(id="uxDecryptedHint").text)
+        self.hint = content.find(id="uxEncryptedHint").text
 
         self.favorites = content.find(
             "strong", text=re.compile("Favorites:")).parent.text.split()[-1]

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -647,7 +647,7 @@ class Cache(object):
             self._trackable_page_url = None
 
         # Additional Waypoints
-        self.waypoints = Waypoint.from_html(root)
+        self.waypoints = Waypoint.from_html(root, "ctl00_ContentBody_Waypoints")
 
         logging.debug("Cache loaded: {}".format(self))
 
@@ -918,14 +918,16 @@ class Waypoint():
         self._note = note
 
     @classmethod
-    def from_html(cls, root, id_="ctl00_ContentBody_Waypoints"):
+    def from_html(cls, soup, table_id):
         """Return a dictionary of all waypoints found in the page
         representation
 
-        :param str id_: html id of the waypoints table
+        :param bs4.BeautifulSoup soup: parsed html document containing the
+            waypoints table
+        :param str table_id: html id of the waypoints table
         """
         waypoints_dict = {}
-        waypoints_table = root.find('table', id=id_)
+        waypoints_table = soup.find('table', id=table_id)
         if waypoints_table:
             waypoints_table = waypoints_table.find_all("tr")
             for r1, r2 in zip(waypoints_table[1::2], waypoints_table[2::2]):

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -8,6 +8,7 @@ from pycaching.cache import Cache, Type, Size, Waypoint
 from pycaching.geocaching import Geocaching
 from pycaching.geo import Point
 from pycaching.log import Log, Type as LogType
+from pycaching.util import parse_date
 
 from test.test_geocaching import _username, _password
 
@@ -211,13 +212,40 @@ class TestMethods(unittest.TestCase):
     @mock.patch("pycaching.Cache.load_quick")
     def test_load_by_guid(self, mock_load, mock_load_quick):
         with self.subTest("normal"):
-            cache = Cache(self.gc, "GC4808G")
+            cache = Cache(self.gc, "GC2WXPN")
             cache.load_by_guid()
-            self.assertEqual(cache.guid, "15ad3a3d-92c1-4f7c-b273-60937bcc2072")
+            self.assertEqual(cache.guid, "5f45114d-1d79-4fdb-93ae-8f49f1d27188")
+            self.assertEqual(cache.name, "Der Schatz vom Luftschloss")
+            self.assertEqual(cache.location, Point("N 49° 57.895' E 008° 12.988'"))
+            self.assertEqual(cache.type, Type.mystery)
+            self.assertEqual(cache.size, Size.large)
+            self.assertEqual(cache.difficulty, 2.5)
+            self.assertEqual(cache.terrain, 1.5)
+            self.assertEqual(cache.author, "engelmz & Punxsutawney Phil")
+            self.assertEqual(cache.hidden, parse_date("23/06/2011"))
+            self.assertDictEqual(cache.attributes, {
+                "bicycles": True,
+                "available": True,
+                "firstaid": True,
+                "parking": True,
+                "onehour": True,
+                "kids": True,
+                "s-tool": True,
+            })
+            self.assertEqual(cache.summary, "Gibt es das Luftschloss wirklich?")
+            self.assertIn("Seit dem 16.", cache.description)
+            self.assertEqual(cache.hint, "Das ist nicht nötig")
+            self.assertGreater(cache.favorites, 380)
+            self.assertEqual(len(cache.waypoints), 2)
 
         with self.subTest("fail"):
             with self.assertRaises(LoadError):
                 cache = Cache(self.gc, "GC123456")
+                cache.load_by_guid()
+
+        with self.subTest("PM-only"):
+            cache = Cache(self.gc, "GC6MKEF")
+            with self.assertRaises(PMOnlyException):
                 cache.load_by_guid()
 
     def test_load_trackables(self):

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -207,6 +207,19 @@ class TestMethods(unittest.TestCase):
                 cache = Cache(self.gc, "GC123456")
                 cache.load_quick()
 
+    @mock.patch("pycaching.Cache.load")
+    @mock.patch("pycaching.Cache.load_quick")
+    def test_load_by_guid(self, mock_load, mock_load_quick):
+        with self.subTest("normal"):
+            cache = Cache(self.gc, "GC4808G")
+            cache.load_by_guid()
+            self.assertEqual(cache.guid, "15ad3a3d-92c1-4f7c-b273-60937bcc2072")
+
+        with self.subTest("fail"):
+            with self.assertRaises(LoadError):
+                cache = Cache(self.gc, "GC123456")
+                cache.load_by_guid()
+
     def test_load_trackables(self):
         cache = Cache(self.gc, "GC26737")  # TB graveyard - will surelly have some trackables
         trackable_list = list(cache.load_trackables(limit=10))

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -21,7 +21,7 @@ class TestProperties(unittest.TestCase):
                        found=False, size=Size.micro, difficulty=1.5, terrain=5, author="human", hidden=date(2000, 1, 1),
                        attributes={"onehour": True, "kids": False, "available": True}, summary="text",
                        description="long text", hint="rot13", favorites=0, pm_only=False,
-                       original_location=Point(), waypoints={})
+                       original_location=Point(), waypoints={}, guid="53d34c4d-12b5-4771-86d3-89318f71efb1")
         self.c._log_page_url = "/seek/log.aspx?ID=1234567&lcn=1"
 
     def test___str__(self):
@@ -40,6 +40,13 @@ class TestProperties(unittest.TestCase):
         with self.subTest("filter invalid"):
             with self.assertRaises(PycachingValueError):
                 self.c.wp = "xxx"
+
+    def test_guid(self):
+        self.assertEqual(self.c.guid, "53d34c4d-12b5-4771-86d3-89318f71efb1")
+
+        with self.subTest("filter invalid"):
+            with self.assertRaises(PycachingValueError):
+                self.c.guid = "123"
 
     def test_name(self):
         self.assertEqual(self.c.name, "Testing")
@@ -202,6 +209,7 @@ class TestMethods(unittest.TestCase):
             cache.load_quick()
             self.assertEqual(4, cache.terrain)
             self.assertEqual(Size.regular, cache.size)
+            self.assertEqual(cache.guid, "15ad3a3d-92c1-4f7c-b273-60937bcc2072")
 
         with self.subTest("fail"):
             with self.assertRaises(LoadError):
@@ -212,9 +220,8 @@ class TestMethods(unittest.TestCase):
     @mock.patch("pycaching.Cache.load_quick")
     def test_load_by_guid(self, mock_load, mock_load_quick):
         with self.subTest("normal"):
-            cache = Cache(self.gc, "GC2WXPN")
+            cache = Cache(self.gc, "GC2WXPN", guid="5f45114d-1d79-4fdb-93ae-8f49f1d27188")
             cache.load_by_guid()
-            self.assertEqual(cache.guid, "5f45114d-1d79-4fdb-93ae-8f49f1d27188")
             self.assertEqual(cache.name, "Der Schatz vom Luftschloss")
             self.assertEqual(cache.location, Point("N 49° 57.895' E 008° 12.988'"))
             self.assertEqual(cache.type, Type.mystery)
@@ -238,13 +245,8 @@ class TestMethods(unittest.TestCase):
             self.assertGreater(cache.favorites, 380)
             self.assertEqual(len(cache.waypoints), 2)
 
-        with self.subTest("fail"):
-            with self.assertRaises(LoadError):
-                cache = Cache(self.gc, "GC123456")
-                cache.load_by_guid()
-
         with self.subTest("PM-only"):
-            cache = Cache(self.gc, "GC6MKEF")
+            cache = Cache(self.gc, "GC6MKEF", guid="53d34c4d-12b5-4771-86d3-89318f71efb1")
             with self.assertRaises(PMOnlyException):
                 cache.load_by_guid()
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -218,7 +218,7 @@ class TestMethods(unittest.TestCase):
 
     @mock.patch("pycaching.Cache.load")
     @mock.patch("pycaching.Cache.load_quick")
-    def test_load_by_guid(self, mock_load, mock_load_quick):
+    def test_load_by_guid(self, mock_load_quick, mock_load):
         with self.subTest("normal"):
             cache = Cache(self.gc, "GC2WXPN", guid="5f45114d-1d79-4fdb-93ae-8f49f1d27188")
             cache.load_by_guid()
@@ -249,6 +249,12 @@ class TestMethods(unittest.TestCase):
             cache = Cache(self.gc, "GC6MKEF", guid="53d34c4d-12b5-4771-86d3-89318f71efb1")
             with self.assertRaises(PMOnlyException):
                 cache.load_by_guid()
+
+        with self.subTest("calls load_quick if no guid"):
+            cache = Cache(self.gc, "GC2WXPN")
+            with self.assertRaises(Exception):
+                cache.load_by_guid()  # Raises error since we mocked load_quick()
+            self.assertTrue(mock_load_quick.called)
 
     def test_load_trackables(self):
         cache = Cache(self.gc, "GC26737")  # TB graveyard - will surelly have some trackables


### PR DESCRIPTION
Implement cache details loading by GUID according to issue #29 
- Add method to retrieve a caches GUID
- Add method to load all cache details from its _print-page_ (with a few exceptions of properties that are not listed there)
- Add `id_` argument to `Waypoints.from_html()` allowing to specify the html-id of the waypoint table to parse
