### PR TITLE
Improve networked tests

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -23,8 +23,6 @@ with Betamax.configure() as config:
     config.before_record(callback=sanitize_cookies)
 
 Betamax.register_serializer(PrettyJSONSerializer)
-session = Session()
-recorder = Betamax(session, default_cassette_options={'serialize_with': 'prettyjson'})
 
 
 class NetworkedTest(unittest.TestCase):
@@ -32,7 +30,9 @@ class NetworkedTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.gc = Geocaching(session=session)
+        cls.session = Session()
+        cls.recorder = Betamax(cls.session, default_cassette_options={'serialize_with': 'prettyjson'})
+        cls.gc = Geocaching(session=cls.session)
         try:
             cls.gc.login(username, password)
         except Error:
@@ -43,4 +43,4 @@ class NetworkedTest(unittest.TestCase):
             # because if we are recording new cassettes this means we cannot get
             # properly logged in.
             cls.gc._logged_in = True  # we're gonna trick it
-            cls.gc._session = session  # it got redefined; fix it
+            cls.gc._session = cls.session  # it got redefined; fix it

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -9,7 +9,7 @@ from pycaching.geo import Point
 from pycaching.geocaching import Geocaching
 from pycaching.log import Log, Type as LogType
 from pycaching.util import parse_date
-from . import recorder, NetworkedTest
+from . import NetworkedTest
 
 
 class TestProperties(unittest.TestCase):
@@ -169,41 +169,41 @@ class TestMethods(NetworkedTest):
     def setUpClass(cls):
         super().setUpClass()
         cls.c = Cache(cls.gc, "GC1PAR2")
-        with recorder.use_cassette('cache_setup'):
+        with cls.recorder.use_cassette('cache_setup'):
             cls.c.load()
 
     def test_load(self):
         with self.subTest("normal (with explicit call of load())"):
-            with recorder.use_cassette('cache_explicit_load'):
+            with self.recorder.use_cassette('cache_explicit_load'):
                 cache = Cache(self.gc, "GC4808G")
                 cache.load()
             self.assertEqual("Nekonecne ticho", cache.name)
 
         with self.subTest("normal"):
-            with recorder.use_cassette('cache_normal_normal'):
+            with self.recorder.use_cassette('cache_normal_normal'):
                 cache = Cache(self.gc, "GC4808G")
                 self.assertEqual("Nekonecne ticho", cache.name)
 
         with self.subTest("non-ascii chars"):
-            with recorder.use_cassette('cache_non-ascii'):
+            with self.recorder.use_cassette('cache_non-ascii'):
                 cache = Cache(self.gc, "GC5VJ0P")
                 self.assertEqual("u parezové chaloupky", cache.hint)
 
         with self.subTest("PM only"):
-            with recorder.use_cassette('cache_PMO'):
+            with self.recorder.use_cassette('cache_PMO'):
                 with self.assertRaises(PMOnlyException):
                     cache = Cache(self.gc, "GC3AHDM")
                     cache.load()
 
         with self.subTest("fail"):
-            with recorder.use_cassette('cache_normal_fail'):
+            with self.recorder.use_cassette('cache_normal_fail'):
                 with self.assertRaises(LoadError):
                     cache = Cache(self.gc, "GC123456")
                     cache.load()
 
     def test_load_quick(self):
         with self.subTest("normal"):
-            with recorder.use_cassette('cache_quick_normal'):
+            with self.recorder.use_cassette('cache_quick_normal'):
                 cache = Cache(self.gc, "GC4808G")
                 cache.load_quick()
             self.assertEqual(4, cache.terrain)
@@ -211,7 +211,7 @@ class TestMethods(NetworkedTest):
             self.assertEqual(cache.guid, "15ad3a3d-92c1-4f7c-b273-60937bcc2072")
 
         with self.subTest("fail"):
-            with recorder.use_cassette('cache_quickload_fail'):
+            with self.recorder.use_cassette('cache_quickload_fail'):
                 with self.assertRaises(LoadError):
                     cache = Cache(self.gc, "GC123456")
                     cache.load_quick()
@@ -221,7 +221,7 @@ class TestMethods(NetworkedTest):
     def test_load_by_guid(self, mock_load_quick, mock_load):
         with self.subTest("normal"):
             cache = Cache(self.gc, "GC2WXPN", guid="5f45114d-1d79-4fdb-93ae-8f49f1d27188")
-            with recorder.use_cassette('cache_guidload_normal'):
+            with self.recorder.use_cassette('cache_guidload_normal'):
                 cache.load_by_guid()
             self.assertEqual(cache.name, "Der Schatz vom Luftschloss")
             self.assertEqual(cache.location, Point("N 49° 57.895' E 008° 12.988'"))
@@ -247,25 +247,25 @@ class TestMethods(NetworkedTest):
 
         with self.subTest("PM-only"):
             cache = Cache(self.gc, "GC6MKEF", guid="53d34c4d-12b5-4771-86d3-89318f71efb1")
-            with recorder.use_cassette('cache_guidload_PMO'):
+            with self.recorder.use_cassette('cache_guidload_PMO'):
                 with self.assertRaises(PMOnlyException):
                     cache.load_by_guid()
 
         with self.subTest("calls load_quick if no guid"):
             cache = Cache(self.gc, "GC2WXPN")
-            with recorder.use_cassette('cache_guidload_fallback'):
+            with self.recorder.use_cassette('cache_guidload_fallback'):
                 with self.assertRaises(Exception):
                     cache.load_by_guid()  # Raises error since we mocked load_quick()
             self.assertTrue(mock_load_quick.called)
 
     def test_load_trackables(self):
         cache = Cache(self.gc, "GC26737")  # TB graveyard - will surelly have some trackables
-        with recorder.use_cassette('cache_trackables'):
+        with self.recorder.use_cassette('cache_trackables'):
             trackable_list = list(cache.load_trackables(limit=10))
         self.assertTrue(isinstance(trackable_list, list))
 
     def test_load_logbook(self):
-        with recorder.use_cassette('cache_logbook'):
+        with self.recorder.use_cassette('cache_logbook'):
             # limit over 100 tests pagination
             log_authors = list(map(lambda log: log.author, self.c.load_logbook(limit=200)))
         for expected_author in ["Dudny-1995", "Sopdet Reviewer", "donovanstangiano83"]:
@@ -274,7 +274,7 @@ class TestMethods(NetworkedTest):
     def test_load_log_page(self):
         expected_types = {t.value for t in (LogType.found_it, LogType.didnt_find_it, LogType.note)}
 
-        with recorder.use_cassette('cache_logpage'):
+        with self.recorder.use_cassette('cache_logpage'):
             # make request
             valid_types, hidden_inputs = self.c._load_log_page()
 

--- a/test/test_geo.py
+++ b/test/test_geo.py
@@ -12,7 +12,7 @@ from pycaching import Cache
 from pycaching.errors import GeocodeError, BadBlockError
 from pycaching.geo import Point, Polygon, Rectangle, Tile, UTFGridPoint, Block
 from pycaching.geo import to_decimal
-from . import recorder, NetworkedTest
+from . import NetworkedTest
 
 _sample_caches_file = path.join(path.dirname(__file__), "sample_caches.csv")
 _sample_utfgrid_file = path.join(path.dirname(__file__), "sample_utfgrid.json")
@@ -69,18 +69,18 @@ class TestPoint(NetworkedTest):
         ref_point = Point(50.08746, 14.42125)
 
         with self.subTest("existing location"):
-            with recorder.use_cassette('geo_location_existing'):
+            with self.recorder.use_cassette('geo_location_existing'):
                 self.assertLess(great_circle(Point.from_location(self.gc, "Prague"), ref_point).miles, 10)
                 self.assertLess(great_circle(Point.from_location(self.gc, "Praha"), ref_point).miles, 10)
                 self.assertLess(great_circle(Point.from_location(self.gc, "praha"), ref_point).miles, 10)
 
         with self.subTest("non-existing location"):
-            with recorder.use_cassette('geo_location_nonexisting'):
+            with self.recorder.use_cassette('geo_location_nonexisting'):
                 with self.assertRaises(GeocodeError):
                     Point.from_location(self.gc, "qwertzuiop")
 
         with self.subTest("empty request"):
-            with recorder.use_cassette('geo_location_empty'):
+            with self.recorder.use_cassette('geo_location_empty'):
                 with self.assertRaises(GeocodeError):
                     Point.from_location(self.gc, "")
 
@@ -186,7 +186,7 @@ class TestTile(NetworkedTest):
 
     def test_download_utfgrid(self):
         """Test if downloading a UTFGrid passes without errors"""
-        with recorder.use_cassette('geo_point_utfgrid'):
+        with self.recorder.use_cassette('geo_point_utfgrid'):
             with self.subTest("not getting .png tile first"):
                 self.tile._download_utfgrid()
 

--- a/test/test_trackable.py
+++ b/test/test_trackable.py
@@ -7,7 +7,7 @@ from unittest import mock
 from pycaching import Geocaching, Trackable
 from pycaching.errors import ValueError as PycachingValueError, LoadError
 from pycaching.log import Log, Type as LogType
-from . import recorder, NetworkedTest
+from . import NetworkedTest
 
 
 class TestProperties(unittest.TestCase):
@@ -53,19 +53,19 @@ class TestMethods(NetworkedTest):
     def setUpClass(cls):
         super().setUpClass()
         cls.t = Trackable(cls.gc, "TB1KEZ9")
-        with recorder.use_cassette('trackable_setup'):
+        with cls.recorder.use_cassette('trackable_setup'):
             cls.t.load()
 
     def test_load(self):
         with self.subTest("tid"):
             trackable = Trackable(self.gc, "TB1KEZ9")
-            with recorder.use_cassette('trackable_load_tid'):
+            with self.recorder.use_cassette('trackable_load_tid'):
                 self.assertEqual("Lilagul #2: SwedenHawk Geocoin", trackable.name)
 
         with self.subTest("trackable url"):
             url = "http://www.geocaching.com/track/details.aspx?guid=cff00ac4-f562-486e-b303-32b2d01ed386"
             trackable = Trackable(self.gc, None, url=url)
-            with recorder.use_cassette('trackable_load_url'):
+            with self.recorder.use_cassette('trackable_load_url'):
                 self.assertEqual("Lilagul #2: SwedenHawk Geocoin", trackable.name)
 
         with self.subTest("fail lazyload"):
@@ -79,7 +79,7 @@ class TestMethods(NetworkedTest):
         expected_date_format = "M/d/yyyy"  # if test is re-recorded, update for your testing account
 
         # make request
-        with recorder.use_cassette('trackable_load_page'):
+        with self.recorder.use_cassette('trackable_load_page'):
             valid_types, hidden_inputs, user_date_format = self.t._load_log_page()
 
         self.assertSequenceEqual(expected_types, valid_types)
@@ -126,7 +126,7 @@ class TestMethods(NetworkedTest):
             mock_request.assert_called_with(self.t._log_page_url, method="POST", data=expected_post_data)
 
     def test_get_KML(self):
-        with recorder.use_cassette('trackable_kml'):
+        with self.recorder.use_cassette('trackable_kml'):
             kml = self.t.get_KML()
         self.assertTrue("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" in kml)
         self.assertTrue("<kml xmlns=\"http://earth.google.com/kml/2.2\">" in kml)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -2,13 +2,12 @@
 
 import datetime
 import itertools
-import unittest
 
 from pycaching.util import rot13, parse_date, format_date, get_possible_attributes
-from . import session, recorder
+from . import NetworkedTest
 
 
-class TestModule(unittest.TestCase):
+class TestModule(NetworkedTest):
     def test_rot13(self):
         self.assertEqual(rot13("Text"), "Grkg")
         self.assertEqual(rot13("abc'ř"), "nop'ř")
@@ -53,8 +52,8 @@ class TestModule(unittest.TestCase):
             self.assertEqual(format_date(date, user_format), ref_result)
 
     def test_get_possible_attributes(self):
-        with recorder.use_cassette('util_attributes'):
-            attributes = get_possible_attributes(session=session)
+        with self.recorder.use_cassette('util_attributes'):
+            attributes = get_possible_attributes(session=self.session)
 
         with self.subTest("existing attributes"):
             for attr in "dogs", "public", "kids":


### PR DESCRIPTION
Fixes #114, I believe.

This changes so that each test class has its own session, `Geocaching` instance, and recorder. Hopefully this will improve the experience of recording new tests.