### PR TITLE
Avoid stopping function my_logs() at premium cache

### DIFF
--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -383,25 +383,16 @@ class Geocaching(object):
         return Cache._from_print_page(self, guid, print_page)
 
     def _try_getting_cache_from_guid(self, guid):
-        """tries to read a geocache from GUID page
-        if this is not possible (because it's a premium only cache) it reads the cache from the GC code"""
+        """Try to get a cache from guid page if possible, otherwise from gccode.
+
+        :param str guid: guid of the cache that should be read in
+        """
         try:
             return self.get_cache(guid=guid)
         except PMOnlyException:
-            url = "https://www.geocaching.com/seek/cache_details.aspx?guid={}".format(guid)
-            wp = self._get_gccode_from_guidpage(url)
+            url = self._request(Cache._urls["cache_details"], params={"guid": guid}, expect="raw").url
+            wp = url.split("/")[4].split("_")[0]  # get gccode from redirected url
             return self.get_cache(wp)
-
-    @staticmethod
-    def _get_gccode_from_guidpage(url):
-        data = requests.get(url).text
-        soup = bs4.BeautifulSoup(data, features="html.parser")
-        gc_element = soup.find("li", class_="li__gccode")
-        if gc_element is not None:                        # PMonly caches, this it what this function is for
-            gccode = gc_element.text.strip()
-        else:
-            gccode = soup.find("span", class_="CoordInfoCode").text.strip()
-        return gccode
 
     def my_logs(self, log_type=None, limit=float('inf')):
         """Get an iterable of the logged-in user's logs.

--- a/test/test_geocaching.py
+++ b/test/test_geocaching.py
@@ -96,19 +96,6 @@ class TestMethods(NetworkedTest):
                 except PMOnlyException:
                     pass
 
-    def test__get_gccode_from_guidpage(self):
-        # for a "normal" cache (not really relevant for program)
-        url_normal = "https://www.geocaching.com/seek/cache_details.aspx?guid={}".format(
-                                            "15ad3a3d-92c1-4f7c-b273-60937bcc2072")
-        wp_normal = self.gc._get_gccode_from_guidpage(url_normal)
-        self.assertEqual(wp_normal, "GC4808G")
-
-        # for PMonly cache
-        url = "https://www.geocaching.com/seek/cache_details.aspx?guid={}".format(
-                                            "328927c1-aa8c-4e0d-bf59-31f1ce44d990")
-        wp = self.gc._get_gccode_from_guidpage(url)
-        self.assertEqual(wp, "GC74HEV")
-
     def test__try_getting_cache_from_guid(self):
         # get "normal" cache from guidpage
         with self.recorder.use_cassette('geocaching_shortcut_getcache__by_guid'):  # is a replacement for login

--- a/test/test_geocaching.py
+++ b/test/test_geocaching.py
@@ -96,6 +96,30 @@ class TestMethods(NetworkedTest):
                 except PMOnlyException:
                     pass
 
+    def test__get_gccode_from_guidpage(self):
+        # for a "normal" cache (not really relevant for program)
+        url_normal = "https://www.geocaching.com/seek/cache_details.aspx?guid={}".format(
+                                            "15ad3a3d-92c1-4f7c-b273-60937bcc2072")
+        wp_normal = self.gc._get_gccode_from_guidpage(url_normal)
+        self.assertEqual(wp_normal, "GC4808G")
+
+        # for PMonly cache
+        url = "https://www.geocaching.com/seek/cache_details.aspx?guid={}".format(
+                                            "328927c1-aa8c-4e0d-bf59-31f1ce44d990")
+        wp = self.gc._get_gccode_from_guidpage(url)
+        self.assertEqual(wp, "GC74HEV")
+
+    def test__try_getting_cache_from_guid(self):
+        # get "normal" cache from guidpage
+        with self.recorder.use_cassette('geocaching_shortcut_getcache__by_guid'):  # is a replacement for login
+            cache = self.gc._try_getting_cache_from_guid('15ad3a3d-92c1-4f7c-b273-60937bcc2072')
+            self.assertEqual("Nekonecne ticho", cache.name)
+
+        # get PMonly cache from GC code (doesn't load any information)
+        cache_pm = self.gc._try_getting_cache_from_guid('328927c1-aa8c-4e0d-bf59-31f1ce44d990')
+        cache_pm.load_quick()  # necessary to get name for PMonly cache
+        self.assertEqual("Nidda: jenseits der Rennstrecke Reloaded", cache_pm.name)
+
 
 class TestLoginOperations(NetworkedTest):
     def setUp(self):


### PR DESCRIPTION
see #117 

I have changed the function my_logs() so that if cache can be read by guid it is read by guid and otherwise -- i. e. if the cache is only for premium members -- it reads the cache by the GC code. So my_logs() doesn't throw an error and you can get the information of the caches you have found before the PMonly cache. It is even possible to get some information on the PMonly cache by cache.load_quick().