### PR TITLE
Add secondary ID for post_reviewer_note log type

### DIFF
--- a/pycaching/log.py
+++ b/pycaching/log.py
@@ -126,6 +126,9 @@ class Type(enum.Enum):
         elif filename == "1001":
             # 2 different IDs for visit
             return cls.visit
+        elif filename == "68":
+            # 2 different IDs for post_reviewer_note
+            return cls.post_reviewer_note
 
         try:
             return cls(filename)


### PR DESCRIPTION
I run into type of log which is currently not supported. It seem like a duplicate of Post Reviewer Log but with id 68.
Cache where I encountered this problem: https://www.geocaching.com/geocache/GCT686