### PR TITLE
Correct lowercase coordinates

### DIFF
--- a/pycaching/geo.py
+++ b/pycaching/geo.py
@@ -54,14 +54,15 @@ class Point(geopy.Point):
         This method can handle various malformed formats. Example inputs are:
 
         - :code:`S 36 51.918 E 174 46.725` or
-        - :code:`N 6 52.861  W174   43.327`
+        - :code:`N 6 52.861  w174   43.327`
 
         :param str string: Coordinates to parse.
         :raise .ValueError: If string cannot be parsed as coordinates.
         """
 
         # Make it uppercase for consistency
-        coords = string.upper().replace("N", " ").replace("S", " ") \
+        string = string.upper() # convert to uppercase to simplify hemisphere comparisons
+        coords = string.replace("N", " ").replace("S", " ") \
             .replace("E", " ").replace("W", " ").replace("+", " ")
 
         try:

--- a/pycaching/geo.py
+++ b/pycaching/geo.py
@@ -60,8 +60,8 @@ class Point(geopy.Point):
         :raise .ValueError: If string cannot be parsed as coordinates.
         """
 
-        # Make it uppercase for consistency
-        string = string.upper() # convert to uppercase to simplify hemisphere comparisons
+        # Convert to uppercase to simplify hemisphere comparisons
+        string = string.upper()
         coords = string.replace("N", " ").replace("S", " ") \
             .replace("E", " ").replace("W", " ").replace("+", " ")
 

--- a/test/test_geo.py
+++ b/test/test_geo.py
@@ -34,6 +34,10 @@ class TestPoint(NetworkedTest):
             self.assertEqual(Point.from_string("S 49 45.123 W 013 22.123"),
                              Point(-49.75205, -13.36872))
 
+        with self.subTest("lowercase"):
+            self.assertEqual(Point.from_string("s 49 45.123 w 013 22.123"),
+                             Point(-49.75205, -13.36872))
+
         with self.subTest("letter together"):
             self.assertEqual(Point.from_string("N49 45.123 E013 22.123"), Point(49.75205, 13.36872))
 
@@ -52,7 +56,7 @@ class TestPoint(NetworkedTest):
             self.assertEqual(Point.from_string("N 49° 45.123 E 013° 22.123"),
                              Point(49.75205, 13.36872))
 
-        with self.subTest("coma between lat and lon"):
+        with self.subTest("comma between lat and lon"):
             self.assertEqual(Point.from_string("N 49 45.123, E 013 22.123"),
                              Point(49.75205, 13.36872))
 


### PR DESCRIPTION
Return the correct hemisphere for an input string with lowercase characters such as "N32 46.000 w111 38.555" 