### PR TITLE
Set correct file encoding for Windows

### DIFF
--- a/test/test_geo.py
+++ b/test/test_geo.py
@@ -203,7 +203,7 @@ class TestTile(NetworkedTest):
         """Parse locally stored grid and compare to expected results"""
 
         # load mock utfgrid from file
-        with open(_sample_utfgrid_file) as f:
+        with open(_sample_utfgrid_file, encoding="utf8") as f:
             mock_utfgrid.return_value = json.load(f)
 
         # load expected caches from file


### PR DESCRIPTION
This fixes the blocks test by setting the UTF-8 encoding when opening the JSON file. Otherwise the corresponding test may fail on Windows because the default encoding (in my case CP-1252) is used which cannot handle some of the characters:

```
======================================================================
ERROR: Parse locally stored grid and compare to expected results
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Python\lib\unittest\mock.py", line 1195, in patched
    return func(*args, **keywargs)
  File "C:\Me\GitHub\pycaching\test\test_geo.py", line 207, in test_blocks
    mock_utfgrid.return_value = json.load(f)
  File "C:\Python\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
  File "C:\Python\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 1346: character maps to <undefined>
```