### PR TITLE
Fix script retrieval to work with bs4 >= 4.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Pycaching has following requirements:
 
     Python>=3.5
     requests>=2.8
-    beautifulsoup4>=4.4
+    beautifulsoup4>=4.9
     geopy>=1.11
 
 Pycaching tests have the following additional requirements:
@@ -66,7 +66,7 @@ Examples
 Login
 ---------------------------------------------------------------------------------------------------
 
-Simly call `pycaching.login()
+Simply call `pycaching.login()
 <https://pycaching.readthedocs.io/en/latest/api.html#pycaching.geocaching.Geocaching.login>`__
 method and it will do everything for you.
 
@@ -179,7 +179,7 @@ Search for all traditional caches around
 
 Notice the ``limit`` in the search function. It is because `geocaching.search()
 <https://pycaching.readthedocs.io/en/latest/api.html#pycaching.geocaching.Geocaching.search>`__
-returns a generator object, which would fetch the caches forever in case of simple loop.
+returns a generator object, which would fetch the caches forever in case of a simple loop.
 
 Geocode adress and search around
 ---------------------------------------------------------------------------------------------------
@@ -210,7 +210,7 @@ Find caches with their approximate locations in some area
         print(cache.name, cache.location.precision)
 
 
-Load a trackable details
+Load trackable details
 ---------------------------------------------------------------------------------------------------
 
 .. code-block:: python
@@ -271,6 +271,10 @@ new cassettes. To run new tests, first set up the following environment variable
 Substitute your username for ``yourusername`` and your password for ``yourpassword``. After you
 have exported the environment variables once, you do not need to export them again, and can run
 tests with just ``python3 setup.py test``.
+
+To re-record a specific cassette in case of site changes, delete the corresponding JSON file and
+provide username and password as explained above. The missing cassette will be recorded for future
+usages.
 
 .. _appendix:
 

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -5,6 +5,7 @@ import datetime
 import re
 import enum
 import os
+from bs4.element import Script
 from pycaching import errors
 from pycaching.geo import Point
 from pycaching.trackable import Trackable
@@ -737,7 +738,7 @@ class Cache(object):
         else:
             self.favorites = 0
 
-        js_content = "\n".join(map(lambda i: i.text, root.find_all("script")))
+        js_content = "\n".join(root.find_all(string=lambda i: isinstance(i, Script)))
         self._logbook_token = re.findall("userToken\\s*=\\s*'([^']+)'", js_content)[0]
         # find original location if any
         if "oldLatLng\":" in js_content:

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ info = {
     "description":         "Geocaching.com site crawler. Provides tools for searching, fetching caches and geocoding.",
     "long_description":    long_description,
     "keywords":            ["geocaching", "crawler", "geocache", "cache", "search", "geocode", "travelbug"],
-    "install_requires":    ["requests>=2.8", "beautifulsoup4>=4.4", "geopy>=1.11"],
+    "install_requires":    ["requests>=2.8", "beautifulsoup4>=4.9", "geopy>=1.11"],
     "tests_require":       ["betamax >=0.8, <0.9", "betamax-serializers >=0.2, <0.3"],
     "setup_requires":      ["nose", "flake8<3.0.0", "coverage"],  # flake8 >= 3.0 has incompatible API
     "cmdclass":            {"test": NoseTestCommand, "lint": LintCommand},


### PR DESCRIPTION
Fix #139 regarding the retrieval of JavaScript objects for bs4 >= 4.9 . This raises the minimum bs4 version to 4.9 as well.

Additionally some typos have been fixed inside the README and a paragraph regarding updating a test cassette has been added.
