### PR TITLE
Remove `sudo` from Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 
 matrix:
   include:
@@ -7,7 +6,6 @@ matrix:
     - python: 3.6
     - python: 3.7
       dist: xenial
-      sudo: true
 
 
 install:


### PR DESCRIPTION
Travis currently reports some warnings regarding the `sudo` keys:

```
Build config validation
root: deprecated key sudo (The key `sudo` has no effect anymore.)
jobs.include: deprecated key sudo (The key `sudo` has no effect anymore.)
```

Elevated access is the default now, see https://changelog.travis-ci.com/the-container-based-build-environment-is-fully-deprecated-84517.