### PR TITLE
Add .uuid field to Log class

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -1041,12 +1041,13 @@ class Cache(object):
                 img_filename = log_data["LogTypeImage"].rsplit(".", 1)[0]  # filename w/o extension
 
                 # create and fill log object
-                log = Log()
-                log.type = LogType.from_filename(img_filename)
-                log.text = log_data["LogText"]
-                log.visited = log_data["Visited"]
-                log.author = log_data["UserName"]
-                yield log
+                yield Log(
+                    uuid=log_data['LogGuid'],
+                    type=LogType.from_filename(img_filename),
+                    text=log_data["LogText"],
+                    visited=log_data["Visited"],
+                    author=log_data["UserName"]
+                )
 
     # TODO: trackable list can have multiple pages - handle it in similar way as _logbook_get_page
     # for example see: http://www.geocaching.com/geocache/GC26737_geocaching-jinak-tb-gc-hrbitov

--- a/pycaching/log.py
+++ b/pycaching/log.py
@@ -12,7 +12,9 @@ _type = type
 class Log(object):
     """Represents a log record with its properties."""
 
-    def __init__(self, *, type=None, text=None, visited=None, author=None):
+    def __init__(self, *, uuid=None, type=None, text=None, visited=None, author=None):
+        if uuid is not None:
+            self.uuid = uuid
         if type is not None:
             self.type = type
         if text is not None:
@@ -25,6 +27,14 @@ class Log(object):
     def __str__(self):
         """Return log text."""
         return self.text
+
+    @property
+    def uuid(self):
+        return self._uuid
+
+    @uuid.setter
+    def uuid(self, uuid):
+        self._uuid = uuid
 
     @property
     def type(self):

--- a/pycaching/log.py
+++ b/pycaching/log.py
@@ -30,6 +30,10 @@ class Log(object):
 
     @property
     def uuid(self):
+        """The log unique identifier.
+
+        :type: :class:`str`
+        """
         return self._uuid
 
     @uuid.setter

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -288,10 +288,24 @@ class TestMethods(NetworkedTest):
 
     def test_load_logbook(self):
         with self.recorder.use_cassette('cache_logbook'):
-            # limit over 100 tests pagination
-            log_authors = list(map(lambda log: log.author, self.c.load_logbook(limit=200)))
-        for expected_author in ["Dudny-1995", "Sopdet Reviewer", "donovanstangiano83"]:
-            self.assertIn(expected_author, log_authors)
+            # limit over 200 tests pagination
+            logs = [
+                (log.uuid, log.author, log.type)
+                for log in self.c.load_logbook(limit=200)
+            ]
+
+            expected_logs = [
+                ('9767f72f-ba69-43ee-affc-44edc0ac8516', 'Dudny-1995', LogType.note),
+                ('a4ea42f1-7020-4503-b704-b8aa7b92d02c', 'Sopdet Reviewer', LogType.archive),
+                ('3f3d3383-adc6-415f-a18a-2c9a96e83238', 'donovanstangiano83', LogType.needs_archive),
+                ('51fbf641-f497-4522-9cdb-2ccd17223567', 'tunklt', LogType.didnt_find_it),
+                ('d4b29fa7-65d5-4fbe-a2f5-aeb4d9a7ee3b', 'ricoo', LogType.temp_disable_listing),
+                ('61607c93-3bec-4314-947f-0fd4bf8939e1', 'showpa', LogType.found_it),
+                ('9d052a22-d615-4bdc-bf25-018e537fda0a', 'Tomasook', LogType.needs_maintenance)
+            ]
+
+            for expected_log in expected_logs:
+                self.assertIn(expected_log, logs)
 
     def test_load_log_page(self):
         expected_types = {t.value for t in (LogType.found_it, LogType.didnt_find_it, LogType.note)}


### PR DESCRIPTION
I have extended `Log` class with `.uuid` field - unique (server side) log identifier. It can be used for identifing and storing logs.

Note: If it is possible, please perform Squash merge type.