### PR TITLE
Read the Docs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+# Enforce *pip*-based build to install package from *pyproject.toml* file.
+python:
+  version: 3
+  install:
+    - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,3 +9,8 @@ python:
   install:
     - method: pip
       path: .
+
+sphinx:
+  configuration: docs/conf.py
+  formats:
+    - pdf


### PR DESCRIPTION
This adds the RTD configuration file as discussed in #168 in an attempt to fix the documentation builds.