### PR TITLE
RTD: fix formats specification

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,5 +12,6 @@ python:
 
 sphinx:
   configuration: docs/conf.py
-  formats:
-    - pdf
+
+formats:
+  - pdf


### PR DESCRIPTION
Format specification is not part of the Sphinx configuration block.