### PR TITLE
Handle missing TB type text like TB19G8B

### DIFF
--- a/pycaching/trackable.py
+++ b/pycaching/trackable.py
@@ -153,7 +153,10 @@ class Trackable(object):
 
     @type.setter
     def type(self, type):
-        self._type = type.strip()
+        if type is None:
+            self._type = ""
+        else:
+          self._type = type.strip()
 
     def get_KML(self):
         """Return the KML route of the trackable.

--- a/pycaching/trackable.py
+++ b/pycaching/trackable.py
@@ -156,7 +156,7 @@ class Trackable(object):
         if type is None:
             self._type = ""
         else:
-          self._type = type.strip()
+            self._type = type.strip()
 
     def get_KML(self):
         """Return the KML route of the trackable.


### PR DESCRIPTION
Reported in #185 

Ran into this with trackable TB19G8B which is missing the alt text on the icon image. 

This is adding a check to gracefully handle this case instead of throwing an exception. 