### PR TITLE
Fix and improve `Geocaching.search_rect()`

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -170,7 +170,7 @@ class Cache(object):
             name=record["name"],
             type=Type.from_number(record["geocacheType"]),
             status=Status(record["cacheStatus"]),
-            found=record["userFound"],
+            found="userFound" in record,
             size=Size.from_number(record["containerType"]),
             difficulty=record["difficulty"],
             terrain=record["terrain"],

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -392,6 +392,7 @@ class Geocaching(object):
         per_query: int = 200,
         sort_by: Union[str, SortOrder] = SortOrder.date_last_visited,
         reverse: bool = False,
+        limit: int = float("inf"),
         origin: Optional[Point] = None,
         wait_sleep: bool = True
     ):
@@ -402,6 +403,7 @@ class Geocaching(object):
         :param int per_query: Number of caches requested in single query.
         :param sort_by: Order cached by given criterion.
         :param reverse: Reverse sort order.
+        :param limit: Maximum number of caches to return.
         :param origin: Origin point for search by distance.
         :param wait_sleep: In case of rate limits exceeding, wait appropriate time if set True,
             otherwise just yield None.
@@ -409,6 +411,10 @@ class Geocaching(object):
         if not isinstance(sort_by, SortOrder):
             sort_by = SortOrder(sort_by)
 
+        if limit <= 0:
+            return
+
+        take_amount = min(limit, per_query)
         params = {
             "box": "{},{},{},{}".format(
                 rect.corners[0].latitude,
@@ -416,7 +422,7 @@ class Geocaching(object):
                 rect.corners[1].latitude,
                 rect.corners[1].longitude,
             ),
-            "take": per_query,
+            "take": take_amount,
             "asc": not reverse,
             "skip": 0,
             "sort": sort_by.value,
@@ -427,7 +433,7 @@ class Geocaching(object):
             params["origin"] = "{},{}".format(origin.latitude, origin.longitude)
 
         total, offset = None, 0
-        while (total is None) or (offset < total):
+        while (offset < limit) and ((total is None) or (offset < total)):
             params["skip"] = offset
 
             try:
@@ -443,7 +449,7 @@ class Geocaching(object):
                 yield Cache._from_api_record(self, record)
 
             total = resp["total"]
-            offset += per_query
+            offset += take_amount
 
     def geocode(self, location):
         """Return a :class:`.Point` object from geocoded location.

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -391,6 +391,7 @@ class Geocaching(object):
         *,
         per_query: int = 200,
         sort_by: Union[str, SortOrder] = SortOrder.date_last_visited,
+        reverse: bool = False,
         origin: Optional[Point] = None,
         wait_sleep: bool = True
     ):
@@ -400,6 +401,7 @@ class Geocaching(object):
         :param rect: Search area.
         :param int per_query: Number of caches requested in single query.
         :param sort_by: Order cached by given criterion.
+        :param reverse: Reverse sort order.
         :param origin: Origin point for search by distance.
         :param wait_sleep: In case of rate limits exceeding, wait appropriate time if set True,
             otherwise just yield None.
@@ -415,7 +417,7 @@ class Geocaching(object):
                 rect.corners[1].longitude,
             ),
             "take": per_query,
-            "asc": "true",
+            "asc": not reverse,
             "skip": 0,
             "sort": sort_by.value,
         }

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -423,7 +423,7 @@ class Geocaching(object):
                 rect.corners[1].longitude,
             ),
             "take": take_amount,
-            "asc": not reverse,
+            "asc": str(not reverse).lower(),
             "skip": 0,
             "sort": sort_by.value,
         }

--- a/test/cassettes/geocaching_api_rate_limit.json
+++ b/test/cassettes/geocaching_api_rate_limit.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2022-02-22T16:27:35",
+      "recorded_at": "2023-01-12T17:12:28",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -21,15 +21,15 @@
             "gspkauth=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=0&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=0&sort=datelastvisited"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNLQ0MTLVUcpLzE1VslIKSS1KrcrMU3AHcosVjAyMjJR0lJLzU0By7s6W5o4B4UCBgqLU3MzSXP+8nEolq7TEnOJUHaW0xLL8osyS1ID8zDyQBQY6Sump+cmJyRmpIZUFQP0mpsYgo/JKEjPzUosgYmY6SimZaWmZyUBHAY0y1APqKkktKgIqgfJKi1OL3PJL84BuhVoEEnHJTPHLL3HLRBIG2xRcklhSCrG8IL+4JDXFOT+/KCUzL7EkFSharZSTWJJZUgryjamBnqmBuaGOUk5+XjpUzNBEz9DU0MS0FuiqVKAzc4pDi3KAHteHeUQfEQQZicXuqfkl+aVFcBcAhXzy012KEtNK4GIFOYnJqSkuQPuB5oCCU9fATNfQIsTAwsrAAIiAJuWXA4MD5DhoMAcEmZkbhlkAZUA+hcZLallqXkhqYq4S0G05icUl4CCBGmtgYGCoC0YhYDMhxpYUJSZnJyblpDoDlQIdBAySotT0zHxgwCodngUMm+Tsw3sVsosSs8AxDFRTBIwBJeeq1OSMzESgWGJJSVFmUik45KCpxcgEnlDCM1JTc5IzEjOLFBKTk1OLizOBVgF1ZRY7FhTkZCaDbFayKikqTa3VgWgGxjVUb1Bqcn5ubmpeSmqKQlp+kUJ2ZkoxXq0mwHiC6g0uKcrPyUlFtxWnVnNE0k7MBibpHKAmhZKMxDyF/LxUhQxQ/KFrB0cd3NWIvBGZWJSioFFQlFkGDHcFYE7KTEnNS07VRDcAxX5jI7h+p8zkymSg/ejqUUMJEUyg+C7PL8pWAKc9dF2otgBjF6orIDM5LzNZoQSkqFghLzWxKKkSr14jC4Te0iSgEpDXgKGcn0uUdlNLuHa3/PwUQlrANiIixaUoMy87My9doRwYpkWENIO9ikgLzom5BSC9+HTF1sbqKJXklyTmKFlZGlka1gICAAD//w6vtkUEBQAA",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDKwNDLXUcpLzE1VslJy9gzxVwhOzCvJzMtUMDIwMlbQVfBNLMo8vDCvOPvwQoWQw3vzMpNTlXSUkvNTQBrcnR2NzQODgAIFRam5maW5/nk5lUpWaYk5xak6SmmJZflFmSWpAfmZeSBbDXSU0lPzkxOTM1JDKguA+g2NQSbllSRm5qUWQYTMdJRSMtPSMpOBDgWaZKgH1FSSWlQEVALlgfUHlySWlEKMLMgvLklNcc7PL0rJzEssSQWKVivlJJZklpSC3GhiqWdpYWpsDLQqJz8vHSpqaKxnYmZoVgu0LRVofU5xaFEO0D/6MPfpI3yWkVjsnppfkl9aBPdYQU5icmqKC9AyoB5QOOkamOgaWYYYmloZGAARUFd+OdBLIJdAQyogyCPQ2TEQKFNanFoEDe/cxCJgUOsVl+RnVyoB3ZKTWFzill+aBzPawMDAUBeMQsDmQowuKUpMzk5Mykl1BiotAYdBUWp6Zj4wgJQCcqpSj3YAI2uvQnZRYhY4poCKioBBqeRclZqckZkIFEssKSnKTCoFhxU0KRiZwFNBeEZqak5yRmJmkUJicnJqcXEm0C6grsxix4KCnMxkkNVKViVFpam1OhDNwEiD6g1KTc7PzU3NS0lNUUjLL1LIzkwpxqvVxBCuN7ikKD8nJxXdVpxaETpd8tPRbUFVamQKVxuQWJSdmZeukJeaWJRUia4L1VsIXZGJRSkKGgVFmWXAmFEA5qPMlNS85FRNvPqNjeD6nTKTK5NzgOGNT70pwr7gjPyiEoWMzOxUBQ0bQ4XsXHSb0HQibPLLTM8oUQAnYnQtkOQL9x0wR+CINVBizywGZll0A1DCFBHrAaVJQCUKwISZV1wAdDgw8+XnoYcwuhngEEKUPR75RcXo4YPuZGNElDsn5hagRyNObRYo2tIygfGHrgMtbBC5IaQoNVUhOSczNwlkXVFqYSlQewp+7aYI7Y5JiXkp+XnAgC0Gejy5pLQIPVpgemNrY3WUSvJLEnOUrCzNjCxrAQEAAP//Ii8TZrAFAAA=",
           "encoding": "utf-8",
           "string": ""
         },
@@ -44,19 +44,19 @@
             "gzip"
           ],
           "Content-Length": [
-            "747"
+            "803"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "f47f2a03-b814-4abd-949b-92e2508ebf9b"
+            "5d3ba5f5-0bfa-45e0-8b98-d41427a68d3a"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:27:34 GMT"
+            "Thu, 12 Jan 2023 17:12:28 GMT"
           ],
           "Set-Cookie": [
-            "jwt=<AUTH COOKIE>; domain=.geocaching.com; path=/; expires=Tue, 22-Feb-2022 17:26:33 GMT; secure; HttpOnly"
+            "jwt=<AUTH COOKIE>; domain=.geocaching.com; path=/; expires=Thu, 12-Jan-2023 18:11:27 GMT; secure; HttpOnly"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -78,11 +78,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=0&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=0&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:27:35",
+      "recorded_at": "2023-01-12T17:12:28",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -102,32 +102,32 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=1&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=1&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8451438,\"name\":\"Dobr\u00e9 r\u00e1no na ho\u0159e \u0158\u00edp 2\",\"code\":\"GC9JF6Z\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":2.5,\"userFound\":false,\"userDidNotFind\":false,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.388017,\"longitude\":14.292067},\"detailsUrl\":\"/geocache/GC9JF6Z\",\"hasGeotour\":false,\"hasLogDraft\":false,\"placedDate\":\"2022-05-14T06:00:00\",\"owner\":{\"code\":\"PR4FQRZ\",\"username\":\"eMichalek\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":63,\"name\":\"Recommended for tourists\",\"isApplicable\":true}]}],\"total\":9291}"
+          "string": "{\"results\":[{\"id\":8857038,\"name\":\"Narozeninov\u00e9 \u0161pek\u00e1\u010dky\",\"code\":\"GCA138V\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":49.862033,\"longitude\":13.76965},\"detailsUrl\":\"/geocache/GCA138V\",\"hasGeotour\":false,\"placedDate\":\"2023-02-12T10:00:00\",\"owner\":{\"code\":\"PRJW5NK\",\"username\":\"Fischi297\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Plze\u0148sk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":65,\"name\":\"Yard (private residence)\",\"isApplicable\":true}]}],\"total\":9629}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
           "Content-Length": [
-            "867"
+            "777"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "746aca6f-d558-44f9-92f0-eda71f610482"
+            "d2e2c4f9-5733-4533-a308-654858ba4747"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:27:35 GMT"
+            "Thu, 12 Jan 2023 17:12:28 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -149,11 +149,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=1&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=1&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:27:35",
+      "recorded_at": "2023-01-12T17:12:29",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -173,32 +173,32 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=2&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=2&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8547077,\"name\":\"ERIK LOUDI HRISKY\",\"code\":\"GC9NNQ3\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":2,\"difficulty\":4.0,\"terrain\":3.5,\"userFound\":false,\"userDidNotFind\":false,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.641917,\"longitude\":14.279433},\"detailsUrl\":\"/geocache/GC9NNQ3\",\"hasGeotour\":false,\"hasLogDraft\":false,\"placedDate\":\"2022-02-19T00:00:00\",\"owner\":{\"code\":\"PRTPB6J\",\"username\":\"Wassermani\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":55,\"name\":\"Short hike (<1 km)\",\"isApplicable\":true},{\"id\":51,\"name\":\"Special tool required\",\"isApplicable\":true},{\"id\":19,\"name\":\"Ticks\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9291}"
+          "string": "{\"results\":[{\"id\":8630552,\"name\":\"Hr\u016fzopt\u00e1k\",\"code\":\"GC9RFJV\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":2,\"difficulty\":4.0,\"terrain\":4.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.69935,\"longitude\":14.28095},\"detailsUrl\":\"/geocache/GC9RFJV\",\"hasGeotour\":false,\"placedDate\":\"2022-04-17T00:00:00\",\"owner\":{\"code\":\"PR2J92V\",\"username\":\"Groot62\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":64,\"name\":\"Tree climbing required\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9629}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
           "Content-Length": [
-            "798"
+            "721"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "b9e7ad52-09d0-4478-8ef5-5bf62d01ef8c"
+            "ba7ae0f9-65fb-4bca-9ccb-68a27c6407d4"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:27:35 GMT"
+            "Thu, 12 Jan 2023 17:12:28 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -220,11 +220,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=2&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=2&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:27:35",
+      "recorded_at": "2023-01-12T17:12:29",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -244,32 +244,32 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=3&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=3&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8503181,\"name\":\"S Arandurem  na kole v Dominik\u00e1nsk\u00e9 republice\",\"code\":\"GC9M723\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"userFound\":false,\"userDidNotFind\":false,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.146683,\"longitude\":14.103583},\"detailsUrl\":\"/geocache/GC9M723\",\"hasGeotour\":false,\"hasLogDraft\":false,\"placedDate\":\"2022-02-24T19:15:00\",\"owner\":{\"code\":\"PR671V8\",\"username\":\"evenTeam\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"St\u0159edo\u010desk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":28,\"name\":\"Public restrooms nearby\",\"isApplicable\":true},{\"id\":27,\"name\":\"Drinking water nearby\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true}]}],\"total\":9291}"
+          "string": "{\"results\":[{\"id\":8857038,\"name\":\"Narozeninov\u00e9 \u0161pek\u00e1\u010dky\",\"code\":\"GCA138V\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":49.862033,\"longitude\":13.76965},\"detailsUrl\":\"/geocache/GCA138V\",\"hasGeotour\":false,\"placedDate\":\"2023-02-12T10:00:00\",\"owner\":{\"code\":\"PRJW5NK\",\"username\":\"Fischi297\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Plze\u0148sk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":65,\"name\":\"Yard (private residence)\",\"isApplicable\":true}]}],\"total\":9629}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
           "Content-Length": [
-            "928"
+            "777"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "66d69507-1f00-48f8-a39f-858b43129766"
+            "3824cef0-58ff-4796-a920-6bcb5342355a"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:27:35 GMT"
+            "Thu, 12 Jan 2023 17:12:29 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -291,11 +291,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=3&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=3&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:27:36",
+      "recorded_at": "2023-01-12T17:12:29",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -315,39 +315,32 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=4&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=4&sort=datelastvisited"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNTE0MTPQUcpLzE1VslIKODrz8Nqc1ILi7MMrFZJKU7IrFYwMjIyUdJSS81NACtydLf3cwiOAAgVFqbmZpbn+eTmVSlZpiTnFqTpKaYll+UWZJakB+Zl5IFuABqen5icnJmekhlQWAPUbGoNMyitJzMxLLYIImekopWSmpWUmAx0GNMlQD6ipJLWoCKhEycoYxCstTi1yyy/NA7oXag9IxCUzxS+/xC0TSRhsUXBJYkkpxO6C/OKS1BTn/PyilMy8xJJUoGi1Uk5iSWZJKcgzpgZ6hqYmJqaWOko5+XnpUFFDEz1jA0tDU/NaoMNSgS7NKQ4tygF6XR/mFX1EIGQkFrun5pfklxbBHQEU8slPdylKTCuBixXkJCanprgAnQA0BxSgugZGukbmIYYmVgYGQAQ0Kb8cGCIg90EDOiDI0sMswgMoA/IsNHqc8rOA/k1UAjotJ7G4BBwoUFMNDAwMdcEoBGwkxNSSosTk7MSknFRnoFKge4CBUpSanpkPDFql4JKjM1NT8o/0pgJje69CdlFiFjiegQqLgBGh5FyVmpyRmQgUSywpKcpMKgUHIDThAGMN6qag1OT83NzUvJTUFIW0/CKF7MyUYqCezGLHgoKczGSQ5UpWJUWlqbU6EK0mhnC9wSVF+Tk5qUUKicnJqcXFmSC1+LQidLrkp6PbgqrU2Aiu1ikzuTI5B+h4fOpNkVxVkJqcmZijUJKfn6NQlFpYmlmUmoKuGdUyE7jmwNJEdP8DhcHpAK7aFK7aPy1Ntyg/MUWhLDUjE92N6DqBoY6wJ6QoNVUhOSczNykzL52QK6H2wjU7w/SlpyYWEdIMjTWEbp/MstTikvzkbIU8oPakSnR9qJYCcxfMyRn5RXnoPkRVbYSINQ9gOgQ5MbEoFZQGseiJrY3VUSrJL0nMUbKyNLI0rAUEAAD//2bpR+HgBAAA",
           "encoding": "utf-8",
-          "string": ""
+          "string": "{\"results\":[{\"id\":8828409,\"name\":\"Kru\u0161nohorsk\u00fd krp\u00e1l\",\"code\":\"GCA04FA\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":8,\"difficulty\":5.0,\"terrain\":5.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.722117,\"longitude\":13.881683},\"detailsUrl\":\"/geocache/GCA04FA\",\"hasGeotour\":false,\"placedDate\":\"2022-09-23T00:00:00\",\"owner\":{\"code\":\"PR33HRK\",\"username\":\"oblac\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":56,\"name\":\"Medium hike (1 km\u201310 km)\",\"isApplicable\":true},{\"id\":44,\"name\":\"Flashlight required\",\"isApplicable\":true},{\"id\":15,\"name\":\"Available in winter\",\"isApplicable\":false},{\"id\":3,\"name\":\"Climbing gear required\",\"isApplicable\":true}]}],\"total\":9629}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
-          "Connection": [
-            "Keep-Alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
           "Content-Length": [
-            "738"
+            "772"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "23d87a87-f03d-4cf2-a843-49c8d71e9d7a"
+            "8f8f7053-a369-40f6-98ca-43176c771064"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:27:36 GMT"
+            "Thu, 12 Jan 2023 17:12:29 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -369,11 +362,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=4&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=4&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:27:36",
+      "recorded_at": "2023-01-12T17:12:30",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -393,15 +386,15 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=5&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=5&sort=datelastvisited"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNbY0MzLUUcpLzE1VslI60pOafXhhbqpCcarC0QVlqVnZqbkKeYkKZZlFJaWHF+ZklyrpKCXnp4DUujtb+rlEeQEFCopSczNLc/3zciqVrNISc4pTdZTSEsvyizJLUgPyM/NAFhroKKWn5icnJmekhlQWAPWbgQzKK0nMzEstgoukZKalZSYDnQg0yFAPqKcktagIqATEM9VRKi1OLXLLL80DuhxqDUjEJTPFL7/ELRNJGGxPcEliSSnE6oL84pLUFOf8/KKUzLzEklSgaLVSTmJJZkkpyC+mBnpGJgYWxsY6Sjn5eelQUUMTPWNDA0vTWqC7UoEOzSkOLcoBelwf5hF9RBBkJBa7p+aX5JcWwd0AFPLJT3cpSkwrgYsV5CQmp6a4AF0ANMfIwMhI18BI18gixNDcytDUysAAaFJ+OTBAQM6DBnNAkHGQq5cbUAbkV2g8eecDw7wE6BUloONyEotLwKECNdfAwMBQF4xCDAyAhkLMLSlKTM5OTMpJdQYqBboIGCpFqemZ+cCwVQouOTozNSX/SG9qcfbhvQrZRYlZ4HgGKiwCxoSSc1VqckZmIlAssaSkKDOpFByC0DQEjDaoq4JSk/Nzc1PzUlJTFNLyixSyM1OKgXoyix0LCnIyk0GWK1mVFJWm1upAtJogUl5wSVF+Tk5qkUJicnJqcXEmSC0+rQidLvnp6LagKrVAWJKcmpeZDEzNqeV4dZjDdYQkZqcWK+QAXaRQkpGYp5Cfl6qQAYplfNqNgEkVqj8gsSg7My9dIS81sSipEq8uU0u4Lrf8/BRCWsAWIcI+oDQJqEQBGMt5xQX5RcCkD4xavGbE1sbqKJXklyTmKFlZGlka1gICAAD//wS/zmofBAAA",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDIxMzHVUcpLzE1VslJy9gzxVwhOzCvJzMtUMDIwMlbQVQjISSyuVNJRSs5PASlxd3Y0dvIOAAoUFKXmZpbm+uflVCpZpSXmFKfqKKUlluUXZZakBuRn5oHsMdBRSk/NT05MzkgNqSwA6jc0BpmUV5KYmZdaBBEy01FKyUxLy0wGOg1okqEeUFNJalERUAmUB9YfXJJYUgoxsiC/uCQ1xTk/vyglMy+xJBUoWq2Uk1iSWVIKcqOJpZ6lsYmhmbmOUk5+XjpU1NBYz9gCCIxrgfalAh2QUxxalAP0kT7MhfoIv2UkFrun5pfklxbBvVaQk5icmuICtA6oBxQ2ugYmusYGIYamVgYGQATUlV8O9BTILdCwCgjyCHR2DATKlBanFkHDODexCBi8esUl+dmVSkC3AIO3xC2/NA9mtIGBgaEuGIWAzYUYXVKUmJydmJST6gxUWgIOhaLU9Mx8YBApBeRUpR7tKM4+vFchuygxCxxXQEVFwMBUcq5KTc7ITASKJZaUFGUmlYJDCxr9RibwmA/PSE3NSc5IzCxSSExOTi0uzgTaBdSVWexYUJCTmQyyWsmqpKg0tVYHohkYbVC9QanJ+bm5qXkpqSkKaflFCtmZKcV4tZoYwvUGlxTl5+SkotuKU6sRIrEGJBZlZ+alK+SlJhYlgVIoui4ktyJ0RSYWpShoFBRllgGDWwGYITJTUvOSUzXx6jc2gut3ykyuTM4BBiI+9aYI+4Iz8otKFDIys1MVNGwMFbJz0W1C04mwyS8zPaNEAZwy0bVA0iTcd8A8hSMqQCk4sxiYE9ENQAlTRFQGlCYBlSgAU1tecQHQ4cA8lZ+HHsLoZoBDCJjZoGZ45BcVo4cPupONESnAOTG3AD0acWqzQNGWlgmMP3QdaGGDSOIhRampCsk5mblJIOuKUgtLgdpT8Gs3RWh3TErMS8nPAwZsMdDjySWlRejRAtMbWxuro1SSX5KYo2RlaWZkWQsIAAD//+SI30R5BQAA",
           "encoding": "utf-8",
           "string": ""
         },
@@ -416,16 +409,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "687"
+            "783"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "c9370e62-db5d-4962-9a4e-8c5e89ad8ae0"
+            "8ccb2f59-a609-48a2-95f3-9b1f2360c9e3"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:27:36 GMT"
+            "Thu, 12 Jan 2023 17:12:30 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -447,11 +440,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=5&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=5&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:27:37",
+      "recorded_at": "2023-01-12T17:12:30",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -471,32 +464,32 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=6&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=6&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8498038,\"name\":\"BOWLING V \u017dATCI 22022022\",\"code\":\"GC9M1P6\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"userFound\":false,\"userDidNotFind\":false,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.3307,\"longitude\":13.538183},\"detailsUrl\":\"/geocache/GC9M1P6\",\"hasGeotour\":false,\"hasLogDraft\":false,\"placedDate\":\"2022-02-22T18:00:00\",\"owner\":{\"code\":\"PRH0ZZ6\",\"username\":\"JaraVeve\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":28,\"name\":\"Public restrooms nearby\",\"isApplicable\":true},{\"id\":59,\"name\":\"Food nearby\",\"isApplicable\":true}]}],\"total\":9291}"
+          "string": "{\"results\":[{\"id\":8917538,\"name\":\"Discop\u0159\u00edb\u011bh - FILMOV\u00c1 M\u00cdSTA\",\"code\":\"GCA347E\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.065,\"longitude\":14.30555},\"detailsUrl\":\"/geocache/GCA347E\",\"hasGeotour\":false,\"placedDate\":\"2023-02-06T17:30:00\",\"owner\":{\"code\":\"PR49M20\",\"username\":\"bumbik\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Hlavn\u00ed m\u011bsto Praha\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":33,\"name\":\"Motorcycles\",\"isApplicable\":true}]}],\"total\":9629}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
           "Content-Length": [
-            "819"
+            "915"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "b97c05cd-907e-4373-b9f9-e25dc3cb19e3"
+            "bf36eb48-a210-41fe-9062-699c35c7b81b"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:27:36 GMT"
+            "Thu, 12 Jan 2023 17:12:30 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -518,11 +511,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=6&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=6&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:27:37",
+      "recorded_at": "2023-01-12T17:12:31",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -542,32 +535,32 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=7&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8543990,\"name\":\"Ukli\u010fme okolo Motolsk\u00fdch rybn\u00edk\u016f\",\"code\":\"GC9NJGG\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":13,\"containerType\":6,\"difficulty\":1.0,\"terrain\":2.0,\"userFound\":false,\"userDidNotFind\":false,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.0679666666667,\"longitude\":14.3372166666667},\"detailsUrl\":\"/geocache/GC9NJGG\",\"hasGeotour\":false,\"hasLogDraft\":false,\"placedDate\":\"2022-04-05T17:30:00\",\"owner\":{\"code\":\"PRKHNA9\",\"username\":\"renanep\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Hlavn\u00ed m\u011bsto Praha\",\"country\":\"Czechia\",\"attributes\":[{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":63,\"name\":\"Recommended for tourists\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true}]}],\"total\":9291}"
+          "string": "{\"results\":[{\"id\":8935788,\"name\":\"Sch\u016fze OKS 20230222\",\"code\":\"GCA3Q75\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.2363166666667,\"longitude\":14.0819166666667},\"detailsUrl\":\"/geocache/GCA3Q75\",\"hasGeotour\":false,\"placedDate\":\"2023-02-22T17:00:00\",\"owner\":{\"code\":\"PR6D6C6\",\"username\":\"ashberry\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"St\u0159edo\u010desk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":8,\"name\":\"Scenic view\",\"isApplicable\":true},{\"id\":7,\"name\":\"Takes less than one hour\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true},{\"id\":19,\"name\":\"Ticks\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9629}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
           "Content-Length": [
-            "800"
+            "1023"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "f0375158-1e24-4f61-b7e3-32b1988dffe7"
+            "46625914-72a7-4d41-a1ca-c67eaac1ffff"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:27:37 GMT"
+            "Thu, 12 Jan 2023 17:12:30 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -589,11 +582,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=7&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:27:37",
+      "recorded_at": "2023-01-12T17:12:31",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -613,32 +606,32 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=8&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=8&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8161589,\"name\":\"Ztracen\u00e1 nad\u011bje\",\"code\":\"GC98QK0\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":2,\"difficulty\":5.0,\"terrain\":4.5,\"userFound\":false,\"userDidNotFind\":false,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.659583,\"longitude\":14.164317},\"detailsUrl\":\"/geocache/GC98QK0\",\"hasGeotour\":false,\"hasLogDraft\":false,\"placedDate\":\"2021-04-04T00:00:00\",\"owner\":{\"code\":\"PR33HRK\",\"username\":\"oblac\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":false},{\"id\":56,\"name\":\"Medium hike (1 km\u201310 km)\",\"isApplicable\":true},{\"id\":47,\"name\":\"Field puzzle\",\"isApplicable\":true},{\"id\":14,\"name\":\"Recommended at night\",\"isApplicable\":false},{\"id\":51,\"name\":\"Special tool required\",\"isApplicable\":true},{\"id\":11,\"name\":\"May require wading\",\"isApplicable\":true}]}],\"total\":9291}"
+          "string": "{\"results\":[{\"id\":8912666,\"name\":\"Vindaloo challenge 2023 - Litom\u011b\u0159ice \u201e(VCH2023)\u201c\",\"code\":\"GCA2Z59\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.533283,\"longitude\":14.135833},\"detailsUrl\":\"/geocache/GCA2Z59\",\"hasGeotour\":false,\"placedDate\":\"2023-01-27T17:30:00\",\"owner\":{\"code\":\"PRYCKKE\",\"username\":\"Tulacka2\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":55,\"name\":\"Short hike (<1 km)\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true}]}],\"total\":9629}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
           "Content-Length": [
-            "941"
+            "790"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "a95d2ecc-6c7b-4b09-9f26-4fe90e289d68"
+            "51b7674e-89f1-44b8-a5c0-f76c6d580a8e"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:27:37 GMT"
+            "Thu, 12 Jan 2023 17:12:31 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -660,11 +653,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=8&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=8&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:27:38",
+      "recorded_at": "2023-01-12T17:12:32",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -684,15 +677,15 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNTYzMTLXUcpLzE1VslLyLso/0puakZNYVpx9eKWCu6t/QWZZvoKxwof5vbtgWElHKTk/BaTc3dnSz9HXAyhQUJSam1ma65+XU6lklZaYU5yqo5SWWJZflFmSGpCfmQey00BHKT01PzkxOSM1pLIAqN8MZFBeSWJmXmoRXCQlMy0tMxnoSqBBhnpAPSWpRUVAJVBeaXFqkVt+aR7Q8VBrQCIumSl++SVumUjCYHuCSxJLSiFWF+QXl6SmOOfnF6Vk5iWWpAJFq5VyEksyS0pBfjE10DM0sjA3NtZRysnPS4eKGproGRqaGZrWAt2VCnRoTnFoUQ7Q4/owj+gjgiAjsdg9Nb8kv7QI7gagkE9+uktRYloJXKwgJzE5NcUF6AKgOUYGRka6Bsa6hgYhhhZWBgZABDQpvxwYICDnQYM5IMjRzd0pBCgD8is0qioTi/JLizNSs5WAjstJLC4BhwrUXAMDA0NdMAoBGwoxt6QoMTk7MSkn1RmoFOgiYKgUpaZn5gPDVim45OjM1BRQ7ANjfq9CdlFiFjiegQqLgDGh5FyVmpyRmQgUSywpKcpMKgWHIDQZGZnAU1B4RmpqTnJGYmaRQmJycmpxcSbQPqCuzGLHgoKczGSQ9UpWJUWlqbU60DQI1xucnJqXmaxQlplajq4DEnowLUamcD0BiUXZmXnpCnmpiUVJlejaUCwyNoLrcspMrkzOAfoAn3ojhMsCSpOAShSA2aekKD8/txjdOmzaTS3h2t3y81MIaQHbCEz/qDYCoyyvuCC/CJiOgfFEyAywtQhXu5Wm5hDSAg4YQ7gW58TcAvTgRI8FuDaETSBtaZnA4EHXgRZviCAJSc1JLcjIz0tFtwqrRjNE1AWnJhbn5yXmQJMXuj40JyICNDgvvzw3PykTPdbR9ViZIRJzSFFqqkJyTmZuEihMilILS4F+TMGv3RSh3TEpMS8F6MUUBWCyKU0uKS1Czwloeg0RJTGw0AR6E5jDFYAFBqj4xK4xtjZWR6kkvyQxR8nK0sjSsBYQAAD//0n5eEfkBQAA",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNTU0MTLUUcpLzE1VslIKyC8tyTu8NlshJV+hqqQoMTk1L1FJRyk5PwUk6+5s6RdmYQ4UKChKzc0szfXPy6lUskpLzClO1VFKSyzLL8osSQ3Iz8wDWWGgo5Semp+cmJyRGlJZANRvATIoryQxMy+1CC6SkpmWlpkMdBTQIFM9oJ6S1KIioBIoD6w9uCSxpBRiYkF+cUlqinN+flFKZl5iSSpQtFopJ7Eks6QU5ERTAz0zSzMLM3MdpZz8vHSoqKGxnoWJuYGxcS3QvlSgA3KKQ4tygB7ShzlQH+G1jMRi99T8kvzSIrjPCnKAAZHiArQOqMfIwMhI18BI18goxMDACoyAuvLLgZ4CuQUaVAFBxsYeQd5AmdLi1CJo6OYnAQ1SAjoiJ7G4xC2/NA9mpoGBgaEuGCGbCQr/7MSknFRnoNISsPeLUtMz84Fho3R4FjAckrMP71XILkrMAkcRUE0RMBCVnKtSkzMyQdGWWFJSlJlUCg4lWITDozoYGLeZyQplmanlQKWZxY4FBTmZySDrlKxKikpTa3UgOkzN4Fp8U1OAka6QkZmdqqBhqJCd+6hhsqEBkNbEa4KhCdyEoNTk/Nzc1LyU1BSFxBKFvMz0jBJ0vZBQh2k2RrjYOTG3IC0TmITx6zA0hetwLAPGNUiJQmaeQjkwWQLjCK9eM4RTQ4pSUxWSczJzkzLz0hWKUgtLgVanoGtH8aiRMVy3S2JeempRfmmxQmJRKigu8OhCZD/nHGBu0Ae6KAdsZ35yNrpf0bQCkwTMq0mJeSn5ecBwzQXmL3RdqPFhifBkJroV6IqNkRRn5BfloatGc5ARXLUHMD2CfIHuf4Se2NpYHaWS/JLEHCUrSzMjy1pAAAAA///uym57oAQAAA==",
           "encoding": "utf-8",
           "string": ""
         },
@@ -707,16 +700,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "813"
+            "694"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "d2ef3f7b-2ca9-4400-9ded-d9b6d0630e36"
+            "2263b5fb-2537-44d9-8c6c-9d77c99847e6"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:27:37 GMT"
+            "Thu, 12 Jan 2023 17:12:31 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -738,11 +731,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:27:38",
+      "recorded_at": "2023-01-12T17:12:32",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -762,11 +755,11 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=10&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=10&sort=datelastvisited"
       },
       "response": {
         "body": {
@@ -784,10 +777,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "517bc0bd-648f-4816-94bb-0eba6f4b6e5b"
+            "30cc3f04-282e-4f5f-a96e-3f6f23e09f94"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:27:37 GMT"
+            "Thu, 12 Jan 2023 17:12:32 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -805,18 +798,18 @@
             "1"
           ],
           "x-rate-limit-reset": [
-            "22"
+            "28"
           ]
         },
         "status": {
           "code": 429,
           "message": ""
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=10&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=10&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:28:05",
+      "recorded_at": "2023-01-12T17:13:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -836,15 +829,15 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=10&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=10&sort=datelastvisited"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjK3MDcAYh2lvMTcVCUrJWfPEH+FgvyUnFSFgqLEvPziksxsBV2FsNS8lNKcRCUdpeT8FJA6d2eLKAMDS6BAQVFqbmZprn9eTqWSVVpiTnGqjlJaYll+UWZJakB+Zh7IMgMdpfTU/OTE5IzUkMoCoH5DY5BJeSWJmXmpRRAhMx2llMy0tMxkoPuAJhnqATWVpBYVAZUoWRmDeKXFqUVu+aV5QGdD7QGJuGSm+OWXuGUiCYMtCi5JLCmF2F0A9EZqinN+flFKZl5iSSpQtFopJ7Eks6QU5BlTAz0DcyMDUx2lnPy8dKigoYmesaWRqYVxLdBdqUCH5hSHFuUAfa4P84k+IgwyEovdU/NL8kuL4G4ACvnkp7sUJaaVwMUKchKTU1NcgC4AmmNkYGSka2Cia2AWYmhuZWxgZWAANCm/HBggIOdBwzkgyMjE3dEQKAPyKzSSShIr8oHGAl2Wk1hcAg4SqKEGBgaGumAUYgAyEWJoSVFicnZiUk6qM1Ap0DnAIClKTc/MBwaskkdOYlne4bUKuUdmF5fkKwQUJWZAohmosggYD0rOVanJGZkgscSSkqLMpFJw+EGTj5EJPOWEZ6Sm5iRnJGYWKSQmJ6cWF2cCLQTqyix2LCjIyUwG2Q8NiVodiG5glEM1B6Um5+fmAhNZaopCWn6RQnZmSjF+vSaGcM3BJUX5OTmp6Pai6C0pKoVrReh0yU8nYA0iZ4QkZqcWK+QALVAoyUjMU8jPS1XIAMU4Xv1GwFQFNSAgsSg7My9dIS81sSipEr82YyO4NqfM5MpkoLXoGtCCAxERbsBEkZGTmZ5RolCUWliaWZSagq4XJThMkUKyIDU5MzFHoSQ/P4eQZqj/LBD+K00CKgFqKwbGR35uMbpHsWpHJAGodmBazSsuyC8C5l5gAiXKDGBZAovPxLz01KL80mKFxKJUUJJF14Xka0SAOSYl5qUAozNFAejy0uSS0iIC6ccSkSgyk7PRYwZNMSIFAUvD4vw8kOuABQGoXMSnzxjJkoz8ojwcqmNrY3WUSvJLEnOUrCyNLA1rAQEAAP//c8ET+uMFAAA=",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDKwNDLTUcpLzE1VslIKKC3JLzu8MO/wWoWqRIXgxLySzLzMXAVdBd/EokygeHH24YUKIYf35mUmpyrpKCXnp4B0uTs7GpsHBgIFCopSczNLc/3zciqVrNISc4pTdZTSEsvyizJLUgPyM/NAVhvoKKWn5icnJmekhlQWAPUDrU/OzytJzMxLLYKLpGSmpWUmAx0LNMhQD6inJLWoCKgEygNrDy5JLCmFmFiQX1ySmuKcn1+UkpmXWJIKFK1WykksySwpBTnRxFLP0sLEwtBcRyknPy8dKmporGdiZmRkaF4LtC8V6ICc4tCiHKCH9GEO1Ed4LSOx2D01vyS/tAjus4KcxOTUFBegdUA9RgZGxroGJrpGliGGZlYGBkAE1JVfDvQUyC3QoAoI8gh0dgSZV1qcWgQN9dzEImA46xWX5GdXKgHdkpNYXOKWX5oHM9rAwMBQF4xCwOZCjC4pSkzOTkzKSXUGKi0Bh0JRanpmPjCIlAJyqlKPdgBja69CdlFiFjiqgIqKgIGp5FyVmpyRmQgUSywpKcpMKgWHFjRBGJnA00J4RmpqTnJGYmaRQmJycmpxcSbQLqCuzGLHgoKczGSQ1UpWJUWlqbU6EM2IdBSUmpyfm5ual5KaopCWX6SQnZlSjFeriSFcb3BJUX5OTiq6rTi1InS65Kej24KqFBj9UKUhidmpxQo5QPMVSjIS8xTy81IVMkBxi0+7sRFcv1NmcmUyUDu6etTwMMYZIKB0lFkMzA749KNkzCSgEgVgnOcVF+QXARM+MKIV8lITi5Iq0c1AdTPCzx75RcXoLgaKgxMzXDkiNJ0Tcwsy89LRLcGuzQJFW1omsKDBr8MMEZbBqYnF+XmJOdAIR9eHZhMiTILz8stz85My0aMBXY+VGSJRhxSlpiok52TmJoG8VpRaWAp0agp+7YbAnAVLYbBSCWIGfn2mCGsdkxLzUoBpLEWhGBg5ySWlRehpGqY3tjZWR6kkvyQxR8nK0szIshYQAAD//ylCge21BQAA",
           "encoding": "utf-8",
           "string": ""
         },
@@ -859,16 +852,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "830"
+            "795"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "a62dff7f-c8a8-416a-a7a9-5237e38b99f1"
+            "25a84382-fe98-48ec-85a3-b537de0e1aa0"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:28:05 GMT"
+            "Thu, 12 Jan 2023 17:13:04 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -890,7 +883,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=10&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=10&sort=datelastvisited"
       }
     }
   ],

--- a/test/cassettes/geocaching_api_rate_limit.json
+++ b/test/cassettes/geocaching_api_rate_limit.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2023-01-12T17:12:28",
+      "recorded_at": "2023-01-12T18:16:18",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -25,11 +25,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=0&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=0&sort=datelastvisited"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDKwNDLXUcpLzE1VslJy9gzxVwhOzCvJzMtUMDIwMlbQVfBNLMo8vDCvOPvwQoWQw3vzMpNTlXSUkvNTQBrcnR2NzQODgAIFRam5maW5/nk5lUpWaYk5xak6SmmJZflFmSWpAfmZeSBbDXSU0lPzkxOTM1JDKguA+g2NQSbllSRm5qUWQYTMdJRSMtPSMpOBDgWaZKgH1FSSWlQEVALlgfUHlySWlEKMLMgvLklNcc7PL0rJzEssSQWKVivlJJZklpSC3GhiqWdpYWpsDLQqJz8vHSpqaKxnYmZoVgu0LRVofU5xaFEO0D/6MPfpI3yWkVjsnppfkl9aBPdYQU5icmqKC9AyoB5QOOkamOgaWYYYmloZGAARUFd+OdBLIJdAQyogyCPQ2TEQKFNanFoEDe/cxCJgUOsVl+RnVyoB3ZKTWFzill+aBzPawMDAUBeMQsDmQowuKUpMzk5Mykl1BiotAYdBUWp6Zj4wgJQCcqpSj3YAI2uvQnZRYhY4poCKioBBqeRclZqckZkIFEssKSnKTCoFhxU0KRiZwFNBeEZqak5yRmJmkUJicnJqcXEm0C6grsxix4KCnMxkkNVKViVFpam1OhDNwEiD6g1KTc7PzU3NS0lNUUjLL1LIzkwpxqvVxBCuN7ikKD8nJxXdVpxaETpd8tPRbUFVamQKVxuQWJSdmZeukJeaWJRUia4L1VsIXZGJRSkKGgVFmWXAmFEA5qPMlNS85FRNvPqNjeD6nTKTK5NzgOGNT70pwr7gjPyiEoWMzOxUBQ0bQ4XsXHSb0HQibPLLTM8oUQAnYnQtkOQL9x0wR+CINVBizywGZll0A1DCFBHrAaVJQCUKwISZV1wAdDgw8+XnoYcwuhngEEKUPR75RcXo4YPuZGNElDsn5hagRyNObRYo2tIygfGHrgMtbBC5IaQoNVUhOSczNwlkXVFqYSlQewp+7aYI7Y5JiXkp+XnAgC0Gejy5pLQIPVpgemNrY3WUSvJLEnOUrCzNjCxrAQEAAP//Ii8TZrAFAAA=",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDKwNDLXUcpLzE1VslJy9gzxVwhOzCvJzMtUMDIwMlbQVfBNLMo8vDCvOPvwQoWQw3vzMpNTlXSUkvNTQBrcnR2NzQODgAIFRam5maW5/nk5lUpWaYk5xak6SmmJZflFmSWpAfmZeSBbDXSU0lPzkxOTM1JDKguA+g2NQSbllSRm5qUWQYTMdJRSMtPSMpOBDgWaZKgH1FSSWlQEVALlgfUHlySWlEKMLMgvLklNcc7PL0rJzEssSQWKVivlJJZklpSC3GhiqWdpYWpsDLQqJz8vHSpqaKxnYmZoVgu0LRVofU5xaFEO0D/6MPfpI3yWkVjsnppfkl9aBPdYQU5icmqKC9AyoB5QOOkamOgaWYYYmloZGAARUFd+OdBLIJdAQyogyCPQ2TEQKFNanFoEDe/cxCJgUOsVl+RnVyoB3ZKTWFzill+aBzPawMDAUBeMQsDmQowuKUpMzk5Mykl1BiotAYdBUWp6Zj4wgJQCcqpSj3YAI2uvQnZRYhY4poCKioBBqeRclZqckZkIFEssKSnKTCoFhxU0KRiZwFNBeEZqak5yRmJmkUJicnJqcXEm0C6grsxix4KCnMxkkNVKViVFpam1OhDNwEiD6g1KTc7PzU3NS0lNUUjLL1LIzkwpxqvVxBCuN7ikKD8nJxXdVpxaETpd8tPRbUFVamQKVxuQWJSdmZeukJeaWJRUia4L1VsIXZGJRSkKGgVFmWXAmFEA5qPMlNS85FRNvPqNjeD6nTKTK5NzgOGNT70pwr7gjPyiEoWMzOxUBQ0bQ4XsXHSb0HQibPLLTM8oUQAnYnQtkOQL9x0wR+CINVBizywGZll0A1DCFBHrAaVJQCUKwISZV1wAdDgw8+XnoYcwuhngEEKUPR75RcXo4YPuZGNElDsn5hagRyNObRYo2tIygfGHrgMtbBC5IaQoNVUhOSczNwlkXVFqYSlQewp+7aYI7Y5JiXkp+XnAgC0Gejy5pLQIPVpgemNrY3WUSvJLEnOUrCzNjCxqAQEAAP//Yx4If7AFAAA=",
           "encoding": "utf-8",
           "string": ""
         },
@@ -50,13 +50,13 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "5d3ba5f5-0bfa-45e0-8b98-d41427a68d3a"
+            "d8a1c13a-aae9-4ee0-b5f3-26c1a407dc59"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:12:28 GMT"
+            "Thu, 12 Jan 2023 18:16:17 GMT"
           ],
           "Set-Cookie": [
-            "jwt=<AUTH COOKIE>; domain=.geocaching.com; path=/; expires=Thu, 12-Jan-2023 18:11:27 GMT; secure; HttpOnly"
+            "jwt=<AUTH COOKIE>; domain=.geocaching.com; path=/; expires=Thu, 12-Jan-2023 19:15:17 GMT; secure; HttpOnly"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -78,11 +78,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=0&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=0&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:12:28",
+      "recorded_at": "2023-01-12T18:16:18",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -106,12 +106,12 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=1&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=1&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8857038,\"name\":\"Narozeninov\u00e9 \u0161pek\u00e1\u010dky\",\"code\":\"GCA138V\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":49.862033,\"longitude\":13.76965},\"detailsUrl\":\"/geocache/GCA138V\",\"hasGeotour\":false,\"placedDate\":\"2023-02-12T10:00:00\",\"owner\":{\"code\":\"PRJW5NK\",\"username\":\"Fischi297\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Plze\u0148sk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":65,\"name\":\"Yard (private residence)\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"results\":[{\"id\":8857038,\"name\":\"Narozeninov\u00e9 \u0161pek\u00e1\u010dky\",\"code\":\"GCA138V\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":49.862033,\"longitude\":13.76965},\"detailsUrl\":\"/geocache/GCA138V\",\"hasGeotour\":false,\"placedDate\":\"2023-02-12T10:00:00\",\"owner\":{\"code\":\"PRJW5NK\",\"username\":\"Fischi297\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Plze\u0148sk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":65,\"name\":\"Yard (private residence)\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
@@ -124,10 +124,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "d2e2c4f9-5733-4533-a308-654858ba4747"
+            "1b277876-05e9-4fa1-a215-e90bd388cb39"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:12:28 GMT"
+            "Thu, 12 Jan 2023 18:16:18 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -149,11 +149,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=1&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=1&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:12:29",
+      "recorded_at": "2023-01-12T18:16:19",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -177,28 +177,28 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=2&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=2&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8630552,\"name\":\"Hr\u016fzopt\u00e1k\",\"code\":\"GC9RFJV\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":2,\"difficulty\":4.0,\"terrain\":4.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.69935,\"longitude\":14.28095},\"detailsUrl\":\"/geocache/GC9RFJV\",\"hasGeotour\":false,\"placedDate\":\"2022-04-17T00:00:00\",\"owner\":{\"code\":\"PR2J92V\",\"username\":\"Groot62\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":64,\"name\":\"Tree climbing required\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"results\":[{\"id\":8911941,\"name\":\"Sch\u016fze OKS 20230126\",\"code\":\"GCA2YCX\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.233567,\"longitude\":14.080483},\"detailsUrl\":\"/geocache/GCA2YCX\",\"hasGeotour\":false,\"placedDate\":\"2023-01-26T17:15:00\",\"owner\":{\"code\":\"PR6D6C6\",\"username\":\"ashberry\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"St\u0159edo\u010desk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":28,\"name\":\"Public restrooms nearby\",\"isApplicable\":true},{\"id\":59,\"name\":\"Food nearby\",\"isApplicable\":true},{\"id\":27,\"name\":\"Drinking water nearby\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
           "Content-Length": [
-            "721"
+            "830"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "ba7ae0f9-65fb-4bca-9ccb-68a27c6407d4"
+            "4dc0cb94-9501-4214-a9e4-6dd58be680ba"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:12:28 GMT"
+            "Thu, 12 Jan 2023 18:16:18 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -220,11 +220,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=2&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=2&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:12:29",
+      "recorded_at": "2023-01-12T18:16:19",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -248,28 +248,28 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=3&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=3&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8857038,\"name\":\"Narozeninov\u00e9 \u0161pek\u00e1\u010dky\",\"code\":\"GCA138V\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":49.862033,\"longitude\":13.76965},\"detailsUrl\":\"/geocache/GCA138V\",\"hasGeotour\":false,\"placedDate\":\"2023-02-12T10:00:00\",\"owner\":{\"code\":\"PRJW5NK\",\"username\":\"Fischi297\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Plze\u0148sk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":65,\"name\":\"Yard (private residence)\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"results\":[{\"id\":8911941,\"name\":\"Sch\u016fze OKS 20230126\",\"code\":\"GCA2YCX\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.233567,\"longitude\":14.080483},\"detailsUrl\":\"/geocache/GCA2YCX\",\"hasGeotour\":false,\"placedDate\":\"2023-01-26T17:15:00\",\"owner\":{\"code\":\"PR6D6C6\",\"username\":\"ashberry\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"St\u0159edo\u010desk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":28,\"name\":\"Public restrooms nearby\",\"isApplicable\":true},{\"id\":59,\"name\":\"Food nearby\",\"isApplicable\":true},{\"id\":27,\"name\":\"Drinking water nearby\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
           "Content-Length": [
-            "777"
+            "830"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "3824cef0-58ff-4796-a920-6bcb5342355a"
+            "ac7a844d-fa4f-4810-a19e-1a3e40ffa416"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:12:29 GMT"
+            "Thu, 12 Jan 2023 18:16:18 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -291,11 +291,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=3&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=3&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:12:29",
+      "recorded_at": "2023-01-12T18:16:19",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -319,12 +319,12 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=4&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=4&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8828409,\"name\":\"Kru\u0161nohorsk\u00fd krp\u00e1l\",\"code\":\"GCA04FA\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":8,\"difficulty\":5.0,\"terrain\":5.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.722117,\"longitude\":13.881683},\"detailsUrl\":\"/geocache/GCA04FA\",\"hasGeotour\":false,\"placedDate\":\"2022-09-23T00:00:00\",\"owner\":{\"code\":\"PR33HRK\",\"username\":\"oblac\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":56,\"name\":\"Medium hike (1 km\u201310 km)\",\"isApplicable\":true},{\"id\":44,\"name\":\"Flashlight required\",\"isApplicable\":true},{\"id\":15,\"name\":\"Available in winter\",\"isApplicable\":false},{\"id\":3,\"name\":\"Climbing gear required\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"results\":[{\"id\":8828409,\"name\":\"Kru\u0161nohorsk\u00fd krp\u00e1l\",\"code\":\"GCA04FA\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":8,\"difficulty\":5.0,\"terrain\":5.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.722117,\"longitude\":13.881683},\"detailsUrl\":\"/geocache/GCA04FA\",\"hasGeotour\":false,\"placedDate\":\"2022-09-23T00:00:00\",\"owner\":{\"code\":\"PR33HRK\",\"username\":\"oblac\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":56,\"name\":\"Medium hike (1 km\u201310 km)\",\"isApplicable\":true},{\"id\":44,\"name\":\"Flashlight required\",\"isApplicable\":true},{\"id\":15,\"name\":\"Available in winter\",\"isApplicable\":false},{\"id\":3,\"name\":\"Climbing gear required\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
@@ -337,10 +337,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "8f8f7053-a369-40f6-98ca-43176c771064"
+            "c6cf85d8-f2e3-4792-9db1-b9c2bfa98600"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:12:29 GMT"
+            "Thu, 12 Jan 2023 18:16:18 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -362,11 +362,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=4&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=4&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:12:30",
+      "recorded_at": "2023-01-12T18:16:19",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -390,11 +390,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=5&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=5&sort=datelastvisited"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDIxMzHVUcpLzE1VslJy9gzxVwhOzCvJzMtUMDIwMlbQVQjISSyuVNJRSs5PASlxd3Y0dvIOAAoUFKXmZpbm+uflVCpZpSXmFKfqKKUlluUXZZakBuRn5oHsMdBRSk/NT05MzkgNqSwA6jc0BpmUV5KYmZdaBBEy01FKyUxLy0wGOg1okqEeUFNJalERUAmUB9YfXJJYUgoxsiC/uCQ1xTk/vyglMy+xJBUoWq2Uk1iSWVIKcqOJpZ6lsYmhmbmOUk5+XjpU1NBYz9gCCIxrgfalAh2QUxxalAP0kT7MhfoIv2UkFrun5pfklxbBvVaQk5icmuICtA6oBxQ2ugYmusYGIYamVgYGQATUlV8O9BTILdCwCgjyCHR2DATKlBanFkHDODexCBi8esUl+dmVSkC3AIO3xC2/NA9mtIGBgaEuGIWAzYUYXVKUmJydmJST6gxUWgIOhaLU9Mx8YBApBeRUpR7tKM4+vFchuygxCxxXQEVFwMBUcq5KTc7ITASKJZaUFGUmlYJDCxr9RibwmA/PSE3NSc5IzCxSSExOTi0uzgTaBdSVWexYUJCTmQyyWsmqpKg0tVYHohkYbVC9QanJ+bm5qXkpqSkKaflFCtmZKcV4tZoYwvUGlxTl5+SkotuKU6sRIrEGJBZlZ+alK+SlJhYlgVIoui4ktyJ0RSYWpShoFBRllgGDWwGYITJTUvOSUzXx6jc2gut3ykyuTM4BBiI+9aYI+4Iz8otKFDIys1MVNGwMFbJz0W1C04mwyS8zPaNEAZwy0bVA0iTcd8A8hSMqQCk4sxiYE9ENQAlTRFQGlCYBlSgAU1tecQHQ4cA8lZ+HHsLoZoBDCJjZoGZ45BcVo4cPupONESnAOTG3AD0acWqzQNGWlgmMP3QdaGGDSOIhRampCsk5mblJIOuKUgtLgdpT8Gs3RWh3TErMS8nPAwZsMdDjySWlRejRAtMbWxuro1SSX5KYo2RlaWZkWQsIAAD//+SI30R5BQAA",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDIxMzHVUcpLzE1VslJy9gzxVwhOzCvJzMtUMDIwMlbQVQjISSyuVNJRSs5PASlxd3Y0dvIOAAoUFKXmZpbm+uflVCpZpSXmFKfqKKUlluUXZZakBuRn5oHsMdBRSk/NT05MzkgNqSwA6jc0BpmUV5KYmZdaBBEy01FKyUxLy0wGOg1okqEeUFNJalERUAmUB9YfXJJYUgoxsiC/uCQ1xTk/vyglMy+xJBUoWq2Uk1iSWVIKcqOJpZ6lsYmhmbmOUk5+XjpU1NBYz9gCCIxrgfalAh2QUxxalAP0kT7MhfoIv2UkFrun5pfklxbBvVaQk5icmuICtA6oBxQ2ugYmusYGIYamVgYGQATUlV8O9BTILdCwCgjyCHR2DATKlBanFkHDODexCBi8esUl+dmVSkC3AIO3xC2/NA9mtIGBgaEuGIWAzYUYXVKUmJydmJST6gxUWgIOhaLU9Mx8YBApBeRUpR7tKM4+vFchuygxCxxXQEVFwMBUcq5KTc7ITASKJZaUFGUmlYJDCxr9RibwmA/PSE3NSc5IzCxSSExOTi0uzgTaBdSVWexYUJCTmQyyWsmqpKg0tVYHohkYbVC9QanJ+bm5qXkpqSkKaflFCtmZKcV4tZoYwvUGlxTl5+SkotuKU6sRIrEGJBZlZ+alK+SlJhYlgVIoui4ktyJ0RSYWpShoFBRllgGDWwGYITJTUvOSUzXx6jc2gut3ykyuTM4BBiI+9aYI+4Iz8otKFDIys1MVNGwMFbJz0W1C04mwyS8zPaNEAZwy0bVA0iTcd8A8hSMqQCk4sxiYE9ENQAlTRFQGlCYBlSgAU1tecQHQ4cA8lZ+HHsLoZoBDCJjZoGZ45BcVo4cPupONESnAOTG3AD0acWqzQNGWlgmMP3QdaGGDSOIhRampCsk5mblJIOuKUgtLgdpT8Gs3RWh3TErMS8nPAwZsMdDjySWlRejRAtMbWxuro1SSX5KYo2RlaWZkUQsIAAD//6W5xF15BQAA",
           "encoding": "utf-8",
           "string": ""
         },
@@ -415,10 +415,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "8ccb2f59-a609-48a2-95f3-9b1f2360c9e3"
+            "eeb000bc-9a4d-48ac-a4ee-a4db7e4b5eaa"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:12:30 GMT"
+            "Thu, 12 Jan 2023 18:16:19 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -440,11 +440,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=5&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=5&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:12:30",
+      "recorded_at": "2023-01-12T18:16:20",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -468,28 +468,35 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=6&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=6&sort=datelastvisited"
       },
       "response": {
         "body": {
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDIxMzHVUcpLzE1VslJy9gzxVwhOzCvJzMtUMDIwMlbQVQjISSyuVNJRSs5PASlxd3Y0dvIOAAoUFKXmZpbm+uflVCpZpSXmFKfqKKUlluUXZZakBuRn5oHsMdBRSk/NT05MzkgNqSwA6jc0BpmUV5KYmZdaBBEy01FKyUxLy0wGOg1okqEeUFNJalERUAmUB9YfXJJYUgoxsiC/uCQ1xTk/vyglMy+xJBUoWq2Uk1iSWVIKcqOJpZ6lsYmhmbmOUk5+XjpU1NBYz9gCCIxrgfalAh2QUxxalAP0kT7MhfoIv2UkFrun5pfklxbBvVaQk5icmuICtA6oBxQ2ugYmusYGIYamVgYGQATUlV8O9BTILdCwCgjyCHR2DATKlBanFkHDODexCBi8esUl+dmVSkC3AIO3xC2/NA9mtIGBgaEuGIWAzYUYXVKUmJydmJST6gxUWgIOhaLU9Mx8YBApBeRUpR7tKM4+vFchuygxCxxXQEVFwMBUcq5KTc7ITASKJZaUFGUmlYJDCxr9RibwmA/PSE3NSc5IzCxSSExOTi0uzgTaBdSVWexYUJCTmQyyWsmqpKg0tVYHohkYbVC9QanJ+bm5qXkpqSkKaflFCtmZKcV4tZoYwvUGlxTl5+SkotuKU6sRIrEGJBZlZ+alK+SlJhYlgVIoui4ktyJ0RSYWpShoFBRllgGDWwGYITJTUvOSUzXx6jc2gut3ykyuTM4BBiI+9aYI+4Iz8otKFDIys1MVNGwMFbJz0W1C04mwyS8zPaNEAZwy0bVA0iTcd8A8hSMqQCk4sxiYE9ENQAlTRFQGlCYBlSgAU1tecQHQ4cA8lZ+HHsLoZoBDCJjZoGZ45BcVo4cPupONESnAOTG3AD0acWqzQNGWlgmMP3QdaGGDSOIhRampCsk5mblJIOuKUgtLgdpT8Gs3RWh3TErMS8nPAwZsMdDjySWlRejRAtMbWxuro1SSX5KYo2RlaWZkUQsIAAD//6W5xF15BQAA",
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8917538,\"name\":\"Discop\u0159\u00edb\u011bh - FILMOV\u00c1 M\u00cdSTA\",\"code\":\"GCA347E\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.065,\"longitude\":14.30555},\"detailsUrl\":\"/geocache/GCA347E\",\"hasGeotour\":false,\"placedDate\":\"2023-02-06T17:30:00\",\"owner\":{\"code\":\"PR49M20\",\"username\":\"bumbik\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Hlavn\u00ed m\u011bsto Praha\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":33,\"name\":\"Motorcycles\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": ""
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
+          "Connection": [
+            "Keep-Alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
           "Content-Length": [
-            "915"
+            "783"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "bf36eb48-a210-41fe-9062-699c35c7b81b"
+            "20e47caa-c6ff-4201-958d-3f59fed3e7d3"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:12:30 GMT"
+            "Thu, 12 Jan 2023 18:16:19 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -511,11 +518,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=6&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=6&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:12:31",
+      "recorded_at": "2023-01-12T18:16:20",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -539,12 +546,12 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=7&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8935788,\"name\":\"Sch\u016fze OKS 20230222\",\"code\":\"GCA3Q75\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.2363166666667,\"longitude\":14.0819166666667},\"detailsUrl\":\"/geocache/GCA3Q75\",\"hasGeotour\":false,\"placedDate\":\"2023-02-22T17:00:00\",\"owner\":{\"code\":\"PR6D6C6\",\"username\":\"ashberry\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"St\u0159edo\u010desk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":8,\"name\":\"Scenic view\",\"isApplicable\":true},{\"id\":7,\"name\":\"Takes less than one hour\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true},{\"id\":19,\"name\":\"Ticks\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"results\":[{\"id\":8935788,\"name\":\"Sch\u016fze OKS 20230222\",\"code\":\"GCA3Q75\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.2363166666667,\"longitude\":14.0819166666667},\"detailsUrl\":\"/geocache/GCA3Q75\",\"hasGeotour\":false,\"placedDate\":\"2023-02-22T17:00:00\",\"owner\":{\"code\":\"PR6D6C6\",\"username\":\"ashberry\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"St\u0159edo\u010desk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":8,\"name\":\"Scenic view\",\"isApplicable\":true},{\"id\":7,\"name\":\"Takes less than one hour\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true},{\"id\":19,\"name\":\"Ticks\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
@@ -557,10 +564,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "46625914-72a7-4d41-a1ca-c67eaac1ffff"
+            "86562425-b245-4267-970b-80e22ac43361"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:12:30 GMT"
+            "Thu, 12 Jan 2023 18:16:19 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -582,11 +589,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=7&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:12:31",
+      "recorded_at": "2023-01-12T18:16:20",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -610,12 +617,12 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=8&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=8&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8912666,\"name\":\"Vindaloo challenge 2023 - Litom\u011b\u0159ice \u201e(VCH2023)\u201c\",\"code\":\"GCA2Z59\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.533283,\"longitude\":14.135833},\"detailsUrl\":\"/geocache/GCA2Z59\",\"hasGeotour\":false,\"placedDate\":\"2023-01-27T17:30:00\",\"owner\":{\"code\":\"PRYCKKE\",\"username\":\"Tulacka2\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":55,\"name\":\"Short hike (<1 km)\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"results\":[{\"id\":8912666,\"name\":\"Vindaloo challenge 2023 - Litom\u011b\u0159ice \u201e(VCH2023)\u201c\",\"code\":\"GCA2Z59\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.533283,\"longitude\":14.135833},\"detailsUrl\":\"/geocache/GCA2Z59\",\"hasGeotour\":false,\"placedDate\":\"2023-01-27T17:30:00\",\"owner\":{\"code\":\"PRYCKKE\",\"username\":\"Tulacka2\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":55,\"name\":\"Short hike (<1 km)\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
@@ -628,10 +635,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "51b7674e-89f1-44b8-a5c0-f76c6d580a8e"
+            "c981e526-87f9-4f25-86c9-bed8f13a7baa"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:12:31 GMT"
+            "Thu, 12 Jan 2023 18:16:19 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -653,11 +660,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=8&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=8&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:12:32",
+      "recorded_at": "2023-01-12T18:16:20",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -681,11 +688,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNTU0MTLUUcpLzE1VslIKyC8tyTu8NlshJV+hqqQoMTk1L1FJRyk5PwUk6+5s6RdmYQ4UKChKzc0szfXPy6lUskpLzClO1VFKSyzLL8osSQ3Iz8wDWWGgo5Semp+cmJyRGlJZANRvATIoryQxMy+1CC6SkpmWlpkMdBTQIFM9oJ6S1KIioBIoD6w9uCSxpBRiYkF+cUlqinN+flFKZl5iSSpQtFopJ7Eks6QU5ERTAz0zSzMLM3MdpZz8vHSoqKGxnoWJuYGxcS3QvlSgA3KKQ4tygB7ShzlQH+G1jMRi99T8kvzSIrjPCnKAAZHiArQOqMfIwMhI18BI18goxMDACoyAuvLLgZ4CuQUaVAFBxsYeQd5AmdLi1CJo6OYnAQ1SAjoiJ7G4xC2/NA9mpoGBgaEuGCGbCQr/7MSknFRnoNISsPeLUtMz84Fho3R4FjAckrMP71XILkrMAkcRUE0RMBCVnKtSkzMyQdGWWFJSlJlUCg4lWITDozoYGLeZyQplmanlQKWZxY4FBTmZySDrlKxKikpTa3UgOkzN4Fp8U1OAka6QkZmdqqBhqJCd+6hhsqEBkNbEa4KhCdyEoNTk/Nzc1LyU1BSFxBKFvMz0jBJ0vZBQh2k2RrjYOTG3IC0TmITx6zA0hetwLAPGNUiJQmaeQjkwWQLjCK9eM4RTQ4pSUxWSczJzkzLz0hWKUgtLgVanoGtH8aiRMVy3S2JeempRfmmxQmJRKigu8OhCZD/nHGBu0Ae6KAdsZ35yNrpf0bQCkwTMq0mJeSn5ecBwzQXmL3RdqPFhifBkJroV6IqNkRRn5BfloatGc5ARXLUHMD2CfIHuf4Se2NpYHaWS/JLEHCUrSzMjy1pAAAAA///uym57oAQAAA==",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNTU0MTLUUcpLzE1VslIKyC8tyTu8NlshJV+hqqQoMTk1L1FJRyk5PwUk6+5s6RdmYQ4UKChKzc0szfXPy6lUskpLzClO1VFKSyzLL8osSQ3Iz8wDWWGgo5Semp+cmJyRGlJZANRvATIoryQxMy+1CC6SkpmWlpkMdBTQIFM9oJ6S1KIioBIoD6w9uCSxpBRiYkF+cUlqinN+flFKZl5iSSpQtFopJ7Eks6QU5ERTAz0zSzMLM3MdpZz8vHSoqKGxnoWJuYGxcS3QvlSgA3KKQ4tygB7ShzlQH+G1jMRi99T8kvzSIrjPCnKAAZHiArQOqMfIwMhI18BI18goxMDACoyAuvLLgZ4CuQUaVAFBxsYeQd5AmdLi1CJo6OYnAQ1SAjoiJ7G4xC2/NA9mpoGBgaEuGCGbCQr/7MSknFRnoNISsPeLUtMz84Fho3R4FjAckrMP71XILkrMAkcRUE0RMBCVnKtSkzMyQdGWWFJSlJlUCg4lWITDozoYGLeZyQplmanlQKWZxY4FBTmZySDrlKxKikpTa3UgOkzN4Fp8U1OAka6QkZmdqqBhqJCd+6hhsqEBkNbEa4KhCdyEoNTk/Nzc1LyU1BSFxBKFvMz0jBJ0vZBQh2k2RrjYOTG3IC0TmITx6zA0hetwLAPGNUiJQmaeQjkwWQLjCK9eM4RTQ4pSUxWSczJzkzLz0hWKUgtLgVanoGtH8aiRMVy3S2JeempRfmmxQmJRKigu8OhCZD/nHGBu0Ae6KAdsZ35yNrpf0bQCkwTMq0mJeSn5ecBwzQXmL3RdqPFhifBkJroV6IqNkRRn5BfloatGc5ARXLUHMD2CfIHuf4Se2NpYHaWS/JLEHCUrSzMji1pAAAAA//+v+3VioAQAAA==",
           "encoding": "utf-8",
           "string": ""
         },
@@ -706,10 +713,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "2263b5fb-2537-44d9-8c6c-9d77c99847e6"
+            "1d7dbdc5-f860-44ad-8d57-5e475d73049e"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:12:31 GMT"
+            "Thu, 12 Jan 2023 18:16:20 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -731,11 +738,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:12:32",
+      "recorded_at": "2023-01-12T18:16:21",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -759,7 +766,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=10&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=10&sort=datelastvisited"
       },
       "response": {
         "body": {
@@ -777,10 +784,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "30cc3f04-282e-4f5f-a96e-3f6f23e09f94"
+            "6f248e3a-2f1e-4957-b65a-c4f0ed32d5ee"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:12:32 GMT"
+            "Thu, 12 Jan 2023 18:16:20 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -798,18 +805,18 @@
             "1"
           ],
           "x-rate-limit-reset": [
-            "28"
+            "39"
           ]
         },
         "status": {
           "code": 429,
           "message": ""
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=10&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=10&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:13:05",
+      "recorded_at": "2023-01-12T18:17:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -833,11 +840,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=10&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=10&sort=datelastvisited"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDKwNDLTUcpLzE1VslIKKC3JLzu8MO/wWoWqRIXgxLySzLzMXAVdBd/EokygeHH24YUKIYf35mUmpyrpKCXnp4B0uTs7GpsHBgIFCopSczNLc/3zciqVrNISc4pTdZTSEsvyizJLUgPyM/NAVhvoKKWn5icnJmekhlQWAPUDrU/OzytJzMxLLYKLpGSmpWUmAx0LNMhQD6inJLWoCKgEygNrDy5JLCmFmFiQX1ySmuKcn1+UkpmXWJIKFK1WykksySwpBTnRxFLP0sLEwtBcRyknPy8dKmporGdiZmRkaF4LtC8V6ICc4tCiHKCH9GEO1Ed4LSOx2D01vyS/tAjus4KcxOTUFBegdUA9RgZGxroGJrpGliGGZlYGBkAE1JVfDvQUyC3QoAoI8gh0dgSZV1qcWgQN9dzEImA46xWX5GdXKgHdkpNYXOKWX5oHM9rAwMBQF4xCwOZCjC4pSkzOTkzKSXUGKi0Bh0JRanpmPjCIlAJyqlKPdgBja69CdlFiFjiqgIqKgIGp5FyVmpyRmQgUSywpKcpMKgWHFjRBGJnA00J4RmpqTnJGYmaRQmJycmpxcSbQLqCuzGLHgoKczGSQ1UpWJUWlqbU6EM2IdBSUmpyfm5ual5KaopCWX6SQnZlSjFeriSFcb3BJUX5OTiq6rTi1InS65Kej24KqFBj9UKUhidmpxQo5QPMVSjIS8xTy81IVMkBxi0+7sRFcv1NmcmUyUDu6etTwMMYZIKB0lFkMzA749KNkzCSgEgVgnOcVF+QXARM+MKIV8lITi5Iq0c1AdTPCzx75RcXoLgaKgxMzXDkiNJ0Tcwsy89LRLcGuzQJFW1omsKDBr8MMEZbBqYnF+XmJOdAIR9eHZhMiTILz8stz85My0aMBXY+VGSJRhxSlpiok52TmJoG8VpRaWAp0agp+7YbAnAVLYbBSCWIGfn2mCGsdkxLzUoBpLEWhGBg5ySWlRehpGqY3tjZWR6kkvyQxR8nK0szIshYQAAD//ylCge21BQAA",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDKwNDLTUcpLzE1VslIKKC3JLzu8MO/wWoWqRIXgxLySzLzMXAVdBd/EokygeHH24YUKIYf35mUmpyrpKCXnp4B0uTs7GpsHBgIFCopSczNLc/3zciqVrNISc4pTdZTSEsvyizJLUgPyM/NAVhvoKKWn5icnJmekhlQWAPUDrU/OzytJzMxLLYKLpGSmpWUmAx0LNMhQD6inJLWoCKgEygNrDy5JLCmFmFiQX1ySmuKcn1+UkpmXWJIKFK1WykksySwpBTnRxFLP0sLEwtBcRyknPy8dKmporGdiZmRkaF4LtC8V6ICc4tCiHKCH9GEO1Ed4LSOx2D01vyS/tAjus4KcxOTUFBegdUA9RgZGxroGJrpGliGGZlYGBkAE1JVfDvQUyC3QoAoI8gh0dgSZV1qcWgQN9dzEImA46xWX5GdXKgHdkpNYXOKWX5oHM9rAwMBQF4xCwOZCjC4pSkzOTkzKSXUGKi0Bh0JRanpmPjCIlAJyqlKPdgBja69CdlFiFjiqgIqKgIGp5FyVmpyRmQgUSywpKcpMKgWHFjRBGJnA00J4RmpqTnJGYmaRQmJycmpxcSbQLqCuzGLHgoKczGSQ1UpWJUWlqbU6EM2IdBSUmpyfm5ual5KaopCWX6SQnZlSjFeriSFcb3BJUX5OTiq6rTi1InS65Kej24KqFBj9UKUhidmpxQo5QPMVSjIS8xTy81IVMkBxi0+7sRFcv1NmcmUyUDu6etTwMMYZIKB0lFkMzA749KNkzCSgEgVgnOcVF+QXARM+MKIV8lITi5Iq0c1AdTPCzx75RcXoLgaKgxMzXDkiNJ0Tcwsy89LRLcGuzQJFW1omsKDBr8MMEZbBqYnF+XmJOdAIR9eHZhMiTILz8stz85My0aMBXY+VGSJRhxSlpiok52TmJoG8VpRaWAp0agp+7YbAnAVLYbBSCWIGfn2mCGsdkxLzUoBpLEWhGBg5ySWlRehpGqY3tjZWR6kkvyQxR8nK0szIohYQAAD//2hzmvS1BQAA",
           "encoding": "utf-8",
           "string": ""
         },
@@ -858,10 +865,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "25a84382-fe98-48ec-85a3-b537de0e1aa0"
+            "91d59ebb-4f43-4c32-91d1-b93a342b3369"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:13:04 GMT"
+            "Thu, 12 Jan 2023 18:17:05 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -883,7 +890,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=10&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=10&sort=datelastvisited"
       }
     }
   ],

--- a/test/cassettes/geocaching_api_rate_limit_with_none.json
+++ b/test/cassettes/geocaching_api_rate_limit_with_none.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2023-01-12T17:13:06",
+      "recorded_at": "2023-01-12T18:17:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -25,11 +25,11 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=0&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=0&sort=datelastvisited"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDKwNDLXUcpLzE1VslJy9gzxVwhOzCvJzMtUMDIwMlbQVfBNLMo8vDCvOPvwQoWQw3vzMpNTlXSUkvNTQBrcnR2NzQODgAIFRam5maW5/nk5lUpWaYk5xak6SmmJZflFmSWpAfmZeSBbDXSU0lPzkxOTM1JDKguA+g2NQSbllSRm5qUWQYTMdJRSMtPSMpOBDgWaZKgH1FSSWlQEVALlgfUHlySWlEKMLMgvLklNcc7PL0rJzEssSQWKVivlJJZklpSC3GhiqWdpYWpsDLQqJz8vHSpqaKxnYmZoVgu0LRVofU5xaFEO0D/6MPfpI3yWkVjsnppfkl9aBPdYQU5icmqKC9AyoB5QOOkamOgaWYYYmloZGAARUFd+OdBLIJdAQyogyCPQ2TEQKFNanFoEDe/cxCJgUOsVl+RnVyoB3ZKTWFzill+aBzPawMDAUBeMQsDmQowuKUpMzk5Mykl1BiotAYdBUWp6Zj4wgJQCcqpSj3YAI2uvQnZRYhY4poCKioBBqeRclZqckZkIFEssKSnKTCoFhxU0KRiZwFNBeEZqak5yRmJmkUJicnJqcXEm0C6grsxix4KCnMxkkNVKViVFpam1OhDNwEiD6g1KTc7PzU3NS0lNUUjLL1LIzkwpxqvVxBCuN7ikKD8nJxXdVpxaETpd8tPRbUFVamQKVxuQWJSdmZeukJeaWJRUia4L1VsIXZGJRSkKGgVFmWXAmFEA5qPMlNS85FRNvPqNjeD6nTKTK5NzgOGNT70pwr7gjPyiEoWMzOxUBQ0bQ4XsXHSb0HQibPLLTM8oUQAnYnQtkOQL9x0wR+CINVBizywGZll0A1DCFBHrAaVJQCUKwISZV1wAdDgw8+XnoYcwuhngEEKUPR75RcXo4YPuZGNElDsn5hagRyNObRYo2tIygfGHrgMtbBC5IaQoNVUhOSczNwlkXVFqYSlQewp+7aYI7Y5JiXkp+XnAgC0Gejy5pLQIPVpgemNrY3WUSvJLEnOUrCzNjCxrAQEAAP//Ii8TZrAFAAA=",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDKwNDLXUcpLzE1VslJy9gzxVwhOzCvJzMtUMDIwMlbQVfBNLMo8vDCvOPvwQoWQw3vzMpNTlXSUkvNTQBrcnR2NzQODgAIFRam5maW5/nk5lUpWaYk5xak6SmmJZflFmSWpAfmZeSBbDXSU0lPzkxOTM1JDKguA+g2NQSbllSRm5qUWQYTMdJRSMtPSMpOBDgWaZKgH1FSSWlQEVALlgfUHlySWlEKMLMgvLklNcc7PL0rJzEssSQWKVivlJJZklpSC3GhiqWdpYWpsDLQqJz8vHSpqaKxnYmZoVgu0LRVofU5xaFEO0D/6MPfpI3yWkVjsnppfkl9aBPdYQU5icmqKC9AyoB5QOOkamOgaWYYYmloZGAARUFd+OdBLIJdAQyogyCPQ2TEQKFNanFoEDe/cxCJgUOsVl+RnVyoB3ZKTWFzill+aBzPawMDAUBeMQsDmQowuKUpMzk5Mykl1BiotAYdBUWp6Zj4wgJQCcqpSj3YAI2uvQnZRYhY4poCKioBBqeRclZqckZkIFEssKSnKTCoFhxU0KRiZwFNBeEZqak5yRmJmkUJicnJqcXEm0C6grsxix4KCnMxkkNVKViVFpam1OhDNwEiD6g1KTc7PzU3NS0lNUUjLL1LIzkwpxqvVxBCuN7ikKD8nJxXdVpxaETpd8tPRbUFVamQKVxuQWJSdmZeukJeaWJRUia4L1VsIXZGJRSkKGgVFmWXAmFEA5qPMlNS85FRNvPqNjeD6nTKTK5NzgOGNT70pwr7gjPyiEoWMzOxUBQ0bQ4XsXHSb0HQibPLLTM8oUQAnYnQtkOQL9x0wR+CINVBizywGZll0A1DCFBHrAaVJQCUKwISZV1wAdDgw8+XnoYcwuhngEEKUPR75RcXo4YPuZGNElDsn5hagRyNObRYo2tIygfGHrgMtbBC5IaQoNVUhOSczNwlkXVFqYSlQewp+7aYI7Y5JiXkp+XnAgC0Gejy5pLQIPVpgemNrY3WUSvJLEnOUrCzNjCxqAQEAAP//Yx4If7AFAAA=",
           "encoding": "utf-8",
           "string": ""
         },
@@ -50,10 +50,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "5354b842-ba77-419b-8eba-795785714be7"
+            "3963919c-e744-4148-b68c-c5b932d37220"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:13:05 GMT"
+            "Thu, 12 Jan 2023 18:17:05 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -75,11 +75,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=0&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=0&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:13:06",
+      "recorded_at": "2023-01-12T18:17:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -103,12 +103,12 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=1&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=1&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8630552,\"name\":\"Hr\u016fzopt\u00e1k\",\"code\":\"GC9RFJV\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":2,\"difficulty\":4.0,\"terrain\":4.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.69935,\"longitude\":14.28095},\"detailsUrl\":\"/geocache/GC9RFJV\",\"hasGeotour\":false,\"placedDate\":\"2022-04-17T00:00:00\",\"owner\":{\"code\":\"PR2J92V\",\"username\":\"Groot62\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":64,\"name\":\"Tree climbing required\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"results\":[{\"id\":8630552,\"name\":\"Hr\u016fzopt\u00e1k\",\"code\":\"GC9RFJV\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":2,\"difficulty\":4.0,\"terrain\":4.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.69935,\"longitude\":14.28095},\"detailsUrl\":\"/geocache/GC9RFJV\",\"hasGeotour\":false,\"placedDate\":\"2022-04-17T00:00:00\",\"owner\":{\"code\":\"PR2J92V\",\"username\":\"Groot62\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":64,\"name\":\"Tree climbing required\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
@@ -121,10 +121,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "773b6e04-cc8d-464e-9b71-e0566b667710"
+            "4908ffbd-386a-4d0e-81fb-8a1487f033b2"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:13:05 GMT"
+            "Thu, 12 Jan 2023 18:17:05 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -146,11 +146,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=1&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=1&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:13:06",
+      "recorded_at": "2023-01-12T18:17:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -174,28 +174,28 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=2&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=2&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8630552,\"name\":\"Hr\u016fzopt\u00e1k\",\"code\":\"GC9RFJV\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":2,\"difficulty\":4.0,\"terrain\":4.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.69935,\"longitude\":14.28095},\"detailsUrl\":\"/geocache/GC9RFJV\",\"hasGeotour\":false,\"placedDate\":\"2022-04-17T00:00:00\",\"owner\":{\"code\":\"PR2J92V\",\"username\":\"Groot62\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":64,\"name\":\"Tree climbing required\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"results\":[{\"id\":8911941,\"name\":\"Sch\u016fze OKS 20230126\",\"code\":\"GCA2YCX\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.233567,\"longitude\":14.080483},\"detailsUrl\":\"/geocache/GCA2YCX\",\"hasGeotour\":false,\"placedDate\":\"2023-01-26T17:15:00\",\"owner\":{\"code\":\"PR6D6C6\",\"username\":\"ashberry\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"St\u0159edo\u010desk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":28,\"name\":\"Public restrooms nearby\",\"isApplicable\":true},{\"id\":59,\"name\":\"Food nearby\",\"isApplicable\":true},{\"id\":27,\"name\":\"Drinking water nearby\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
           "Content-Length": [
-            "721"
+            "830"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "09156743-4617-41f8-bd5d-6c1d20bc33f5"
+            "b8779238-3d22-4ace-96f2-8b4d9defb02b"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:13:06 GMT"
+            "Thu, 12 Jan 2023 18:17:05 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -217,11 +217,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=2&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=2&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:13:07",
+      "recorded_at": "2023-01-12T18:17:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -245,12 +245,12 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=3&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=3&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8857038,\"name\":\"Narozeninov\u00e9 \u0161pek\u00e1\u010dky\",\"code\":\"GCA138V\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":49.862033,\"longitude\":13.76965},\"detailsUrl\":\"/geocache/GCA138V\",\"hasGeotour\":false,\"placedDate\":\"2023-02-12T10:00:00\",\"owner\":{\"code\":\"PRJW5NK\",\"username\":\"Fischi297\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Plze\u0148sk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":65,\"name\":\"Yard (private residence)\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"results\":[{\"id\":8857038,\"name\":\"Narozeninov\u00e9 \u0161pek\u00e1\u010dky\",\"code\":\"GCA138V\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":49.862033,\"longitude\":13.76965},\"detailsUrl\":\"/geocache/GCA138V\",\"hasGeotour\":false,\"placedDate\":\"2023-02-12T10:00:00\",\"owner\":{\"code\":\"PRJW5NK\",\"username\":\"Fischi297\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Plze\u0148sk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":65,\"name\":\"Yard (private residence)\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
@@ -263,10 +263,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "601428c3-eb5e-4dea-b3b8-f84a2bb84e9a"
+            "49dedd16-bff6-4a3a-b886-f3e29bc1035e"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:13:06 GMT"
+            "Thu, 12 Jan 2023 18:17:06 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -288,11 +288,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=3&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=3&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:13:07",
+      "recorded_at": "2023-01-12T18:17:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -316,12 +316,12 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=4&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=4&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8828409,\"name\":\"Kru\u0161nohorsk\u00fd krp\u00e1l\",\"code\":\"GCA04FA\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":8,\"difficulty\":5.0,\"terrain\":5.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.722117,\"longitude\":13.881683},\"detailsUrl\":\"/geocache/GCA04FA\",\"hasGeotour\":false,\"placedDate\":\"2022-09-23T00:00:00\",\"owner\":{\"code\":\"PR33HRK\",\"username\":\"oblac\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":56,\"name\":\"Medium hike (1 km\u201310 km)\",\"isApplicable\":true},{\"id\":44,\"name\":\"Flashlight required\",\"isApplicable\":true},{\"id\":15,\"name\":\"Available in winter\",\"isApplicable\":false},{\"id\":3,\"name\":\"Climbing gear required\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"results\":[{\"id\":8828409,\"name\":\"Kru\u0161nohorsk\u00fd krp\u00e1l\",\"code\":\"GCA04FA\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":8,\"difficulty\":5.0,\"terrain\":5.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.722117,\"longitude\":13.881683},\"detailsUrl\":\"/geocache/GCA04FA\",\"hasGeotour\":false,\"placedDate\":\"2022-09-23T00:00:00\",\"owner\":{\"code\":\"PR33HRK\",\"username\":\"oblac\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":56,\"name\":\"Medium hike (1 km\u201310 km)\",\"isApplicable\":true},{\"id\":44,\"name\":\"Flashlight required\",\"isApplicable\":true},{\"id\":15,\"name\":\"Available in winter\",\"isApplicable\":false},{\"id\":3,\"name\":\"Climbing gear required\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
@@ -334,10 +334,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "250fd485-b5bb-4ead-bbb9-f2fbba52d565"
+            "424d56ef-4ecd-4559-bc3e-6f7715026453"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:13:07 GMT"
+            "Thu, 12 Jan 2023 18:17:06 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -359,11 +359,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=4&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=4&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:13:08",
+      "recorded_at": "2023-01-12T18:17:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -387,12 +387,12 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=5&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=5&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8917538,\"name\":\"Discop\u0159\u00edb\u011bh - FILMOV\u00c1 M\u00cdSTA\",\"code\":\"GCA347E\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.065,\"longitude\":14.30555},\"detailsUrl\":\"/geocache/GCA347E\",\"hasGeotour\":false,\"placedDate\":\"2023-02-06T17:30:00\",\"owner\":{\"code\":\"PR49M20\",\"username\":\"bumbik\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Hlavn\u00ed m\u011bsto Praha\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":33,\"name\":\"Motorcycles\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"results\":[{\"id\":8917538,\"name\":\"Discop\u0159\u00edb\u011bh - FILMOV\u00c1 M\u00cdSTA\",\"code\":\"GCA347E\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.065,\"longitude\":14.30555},\"detailsUrl\":\"/geocache/GCA347E\",\"hasGeotour\":false,\"placedDate\":\"2023-02-06T17:30:00\",\"owner\":{\"code\":\"PR49M20\",\"username\":\"bumbik\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Hlavn\u00ed m\u011bsto Praha\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":33,\"name\":\"Motorcycles\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
@@ -405,10 +405,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "5be6301b-1975-4d45-bd07-c0031dc18b21"
+            "0a57f82f-bf5f-4e9b-9a55-00bd1b52c0f4"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:13:08 GMT"
+            "Thu, 12 Jan 2023 18:17:06 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -430,11 +430,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=5&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=5&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:13:09",
+      "recorded_at": "2023-01-12T18:17:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -458,12 +458,12 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=6&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=6&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8917538,\"name\":\"Discop\u0159\u00edb\u011bh - FILMOV\u00c1 M\u00cdSTA\",\"code\":\"GCA347E\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.065,\"longitude\":14.30555},\"detailsUrl\":\"/geocache/GCA347E\",\"hasGeotour\":false,\"placedDate\":\"2023-02-06T17:30:00\",\"owner\":{\"code\":\"PR49M20\",\"username\":\"bumbik\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Hlavn\u00ed m\u011bsto Praha\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":33,\"name\":\"Motorcycles\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"results\":[{\"id\":8917538,\"name\":\"Discop\u0159\u00edb\u011bh - FILMOV\u00c1 M\u00cdSTA\",\"code\":\"GCA347E\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.065,\"longitude\":14.30555},\"detailsUrl\":\"/geocache/GCA347E\",\"hasGeotour\":false,\"placedDate\":\"2023-02-06T17:30:00\",\"owner\":{\"code\":\"PR49M20\",\"username\":\"bumbik\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Hlavn\u00ed m\u011bsto Praha\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":33,\"name\":\"Motorcycles\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
@@ -476,10 +476,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "2f7090bd-2eee-4631-a5cf-0b739f4b0de1"
+            "38e94cc6-7907-4ca4-b46f-1c748f64557f"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:13:08 GMT"
+            "Thu, 12 Jan 2023 18:17:06 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -501,11 +501,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=6&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=6&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2023-01-12T17:13:09",
+      "recorded_at": "2023-01-12T18:17:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -529,12 +529,456 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=7&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8935788,\"name\":\"Sch\u016fze OKS 20230222\",\"code\":\"GCA3Q75\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.2363166666667,\"longitude\":14.0819166666667},\"detailsUrl\":\"/geocache/GCA3Q75\",\"hasGeotour\":false,\"placedDate\":\"2023-02-22T17:00:00\",\"owner\":{\"code\":\"PR6D6C6\",\"username\":\"ashberry\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"St\u0159edo\u010desk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":8,\"name\":\"Scenic view\",\"isApplicable\":true},{\"id\":7,\"name\":\"Takes less than one hour\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true},{\"id\":19,\"name\":\"Ticks\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9629}"
+          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "16e704d5-afb4-4048-a3cf-32cf6ca231bf"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 18:17:07 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ],
+          "x-rate-limit-reset": [
+            "53"
+          ]
+        },
+        "status": {
+          "code": 429,
+          "message": ""
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T18:17:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "190e35ab-fa9a-451f-9c88-3e2051f6037a"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 18:17:17 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ],
+          "x-rate-limit-reset": [
+            "43"
+          ]
+        },
+        "status": {
+          "code": 429,
+          "message": ""
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T18:17:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "7388fd69-fa45-43d0-aa4a-a0e472f734d6"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 18:17:27 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ],
+          "x-rate-limit-reset": [
+            "33"
+          ]
+        },
+        "status": {
+          "code": 429,
+          "message": ""
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T18:17:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "dad0fd3a-2880-4a89-9b86-ed5609046707"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 18:17:37 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ],
+          "x-rate-limit-reset": [
+            "23"
+          ]
+        },
+        "status": {
+          "code": 429,
+          "message": ""
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T18:17:48",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "1501455e-f340-497e-bc11-e6435784ef6c"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 18:17:47 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ],
+          "x-rate-limit-reset": [
+            "12"
+          ]
+        },
+        "status": {
+          "code": 429,
+          "message": ""
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T18:17:58",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "3c762585-a2a7-4d2a-9f42-9601dc30c97f"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 18:17:57 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ],
+          "x-rate-limit-reset": [
+            "2"
+          ]
+        },
+        "status": {
+          "code": 429,
+          "message": ""
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T18:18:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"results\":[{\"id\":8935788,\"name\":\"Sch\u016fze OKS 20230222\",\"code\":\"GCA3Q75\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.2363166666667,\"longitude\":14.0819166666667},\"detailsUrl\":\"/geocache/GCA3Q75\",\"hasGeotour\":false,\"placedDate\":\"2023-02-22T17:00:00\",\"owner\":{\"code\":\"PR6D6C6\",\"username\":\"ashberry\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"St\u0159edo\u010desk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":8,\"name\":\"Scenic view\",\"isApplicable\":true},{\"id\":7,\"name\":\"Takes less than one hour\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true},{\"id\":19,\"name\":\"Ticks\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9628}"
         },
         "headers": {
           "Cache-Control": [
@@ -547,10 +991,10 @@
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "94ffc834-2812-4e72-8c3a-58eeb7c5c9bc"
+            "921b7949-1fea-4278-b05b-c90c5647de48"
           ],
           "Date": [
-            "Thu, 12 Jan 2023 17:13:09 GMT"
+            "Thu, 12 Jan 2023 18:18:07 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -572,526 +1016,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=7&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2023-01-12T17:13:10",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.28.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=8&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8912666,\"name\":\"Vindaloo challenge 2023 - Litom\u011b\u0159ice \u201e(VCH2023)\u201c\",\"code\":\"GCA2Z59\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.533283,\"longitude\":14.135833},\"detailsUrl\":\"/geocache/GCA2Z59\",\"hasGeotour\":false,\"placedDate\":\"2023-01-27T17:30:00\",\"owner\":{\"code\":\"PRYCKKE\",\"username\":\"Tulacka2\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":55,\"name\":\"Short hike (<1 km)\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true}]}],\"total\":9629}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "max-age=60, private"
-          ],
-          "Content-Length": [
-            "790"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "e23847e2-b526-437d-b24a-d8046085df28"
-          ],
-          "Date": [
-            "Thu, 12 Jan 2023 17:13:09 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=8&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2023-01-12T17:13:10",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.28.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "private"
-          ],
-          "Content-Length": [
-            "54"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "c6ee9723-88f7-4d0b-a311-ec4c288e7758"
-          ],
-          "Date": [
-            "Thu, 12 Jan 2023 17:13:09 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ],
-          "x-rate-limit-reset": [
-            "50"
-          ]
-        },
-        "status": {
-          "code": 429,
-          "message": ""
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2023-01-12T17:13:20",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.28.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "private"
-          ],
-          "Content-Length": [
-            "54"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "24d1c423-4fbc-4cd5-8676-40c334744fd2"
-          ],
-          "Date": [
-            "Thu, 12 Jan 2023 17:13:19 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ],
-          "x-rate-limit-reset": [
-            "40"
-          ]
-        },
-        "status": {
-          "code": 429,
-          "message": ""
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2023-01-12T17:13:30",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.28.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "private"
-          ],
-          "Content-Length": [
-            "54"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "1528f87b-bf21-430b-b545-fadc1e4a9520"
-          ],
-          "Date": [
-            "Thu, 12 Jan 2023 17:13:29 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ],
-          "x-rate-limit-reset": [
-            "30"
-          ]
-        },
-        "status": {
-          "code": 429,
-          "message": ""
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2023-01-12T17:13:41",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.28.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "private"
-          ],
-          "Content-Length": [
-            "54"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "2d29639b-4ed3-41cc-8e57-360de751439d"
-          ],
-          "Date": [
-            "Thu, 12 Jan 2023 17:13:40 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ],
-          "x-rate-limit-reset": [
-            "20"
-          ]
-        },
-        "status": {
-          "code": 429,
-          "message": ""
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2023-01-12T17:13:51",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.28.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "private"
-          ],
-          "Content-Length": [
-            "54"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "13687b77-8dbd-40af-9ca3-b47e961d4c57"
-          ],
-          "Date": [
-            "Thu, 12 Jan 2023 17:13:51 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ],
-          "x-rate-limit-reset": [
-            "9"
-          ]
-        },
-        "status": {
-          "code": 429,
-          "message": ""
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2023-01-12T17:14:01",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.28.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNTU0MTLUUcpLzE1VslIKyC8tyTu8NlshJV+hqqQoMTk1L1FJRyk5PwUk6+5s6RdmYQ4UKChKzc0szfXPy6lUskpLzClO1VFKSyzLL8osSQ3Iz8wDWWGgo5Semp+cmJyRGlJZANRvATIoryQxMy+1CC6SkpmWlpkMdBTQIFM9oJ6S1KIioBIoD6w9uCSxpBRiYkF+cUlqinN+flFKZl5iSSpQtFopJ7Eks6QU5ERTAz0zSzMLM3MdpZz8vHSoqKGxnoWJuYGxcS3QvlSgA3KKQ4tygB7ShzlQH+G1jMRi99T8kvzSIrjPCnKAAZHiArQOqMfIwMhI18BI18goxMDACoyAuvLLgZ4CuQUaVAFBxsYeQd5AmdLi1CJo6OYnAQ1SAjoiJ7G4xC2/NA9mpoGBgaEuGCGbCQr/7MSknFRnoNISsPeLUtMz84Fho3R4FjAckrMP71XILkrMAkcRUE0RMBCVnKtSkzMyQdGWWFJSlJlUCg4lWITDozoYGLeZyQplmanlQKWZxY4FBTmZySDrlKxKikpTa3UgOkzN4Fp8U1OAka6QkZmdqqBhqJCd+6hhsqEBkNbEa4KhCdyEoNTk/Nzc1LyU1BSFxBKFvMz0jBJ0vZBQh2k2RrjYOTG3IC0TmITx6zA0hetwLAPGNUiJQmaeQjkwWQLjCK9eM4RTQ4pSUxWSczJzkzLz0hWKUgtLgVanoGtH8aiRMVy3S2JeempRfmmxQmJRKigu8OhCZD/nHGBu0Ae6KAdsZ35yNrpf0bQCkwTMq0mJeSn5ecBwzQXmL3RdqPFhifBkJroV6IqNkRRn5BfloatGc5ARXLUHMD2CfIHuf4Se2NpYHaWS/JLEHCUrSzMjy1pAAAAA///uym57oAQAAA==",
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Cache-Control": [
-            "max-age=60, private"
-          ],
-          "Connection": [
-            "Keep-Alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Length": [
-            "694"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "0ea3a689-0cb7-4475-9275-db05a20c6a70"
-          ],
-          "Date": [
-            "Thu, 12 Jan 2023 17:14:01 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
       }
     }
   ],

--- a/test/cassettes/geocaching_api_rate_limit_with_none.json
+++ b/test/cassettes/geocaching_api_rate_limit_with_none.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2022-02-22T16:28:05",
+      "recorded_at": "2023-01-12T17:13:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -21,15 +21,15 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=0&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=0&sort=datelastvisited"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNLQ0MTLVUcpLzE1VslIKSS1KrcrMU3AHcosVjAyMjJR0lJLzU0By7s6W5o4B4UCBgqLU3MzSXP+8nEolq7TEnOJUHaW0xLL8osyS1ID8zDyQBQY6Sump+cmJyRmpIZUFQP0mpsYgo/JKEjPzUosgYmY6SimZaWmZyUBHAY0y1APqKkktKgIqgfJKi1OL3PJL84BuhVoEEnHJTPHLL3HLRBIG2xRcklhSCrG8IL+4JDXFOT+/KCUzL7EkFSharZSTWJJZUgryjamBnqmBuaGOUk5+XjpUzNBEz9DU0MS0FuiqVKAzc4pDi3KAHteHeUQfEQQZicXuqfkl+aVFcBcAhXzy012KEtNK4GIFOYnJqSkuQPuB5oCCU9fATNfQIsTAwsrAAIiAJuWXA4MD5DhoMAcEmZkbhlkAZUA+hcZLallqXkhqYq4S0G05icUl4CCBGmtgYGCoC0YhYDMhxpYUJSZnJyblpDoDlQIdBAySotT0zHxgwCodngUMm+Tsw3sVsosSs8AxDFRTBIwBJeeq1OSMzESgWGJJSVFmUik45KCpxcgEnlDCM1JTc5IzEjOLFBKTk1OLizOBVgF1ZRY7FhTkZCaDbFayKikqTa3VgWgGxjVUb1Bqcn5ubmpeSmqKQlp+kUJ2ZkoxXq0mwHiC6g0uKcrPyUlFtxWnVnNE0k7MBibpHKAmhZKMxDyF/LxUhQxQ/KFrB0cd3NWIvBGZWJSioFFQlFkGDHcFYE7KTEnNS07VRDcAxX5jI7h+p8zkymSg/ejqUUMJEUyg+C7PL8pWAKc9dF2otgBjF6orIDM5LzNZoQSkqFghLzWxKKkSr14jC4Te0iSgEpDXgKGcn0uUdlNLuHa3/PwUQlrANiIixaUoMy87My9doRwYpkWENIO9ikgLzom5BSC9+HTF1sbqKJXklyTmKFlZGlka1gICAAD//w6vtkUEBQAA",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwNDKwNDLXUcpLzE1VslJy9gzxVwhOzCvJzMtUMDIwMlbQVfBNLMo8vDCvOPvwQoWQw3vzMpNTlXSUkvNTQBrcnR2NzQODgAIFRam5maW5/nk5lUpWaYk5xak6SmmJZflFmSWpAfmZeSBbDXSU0lPzkxOTM1JDKguA+g2NQSbllSRm5qUWQYTMdJRSMtPSMpOBDgWaZKgH1FSSWlQEVALlgfUHlySWlEKMLMgvLklNcc7PL0rJzEssSQWKVivlJJZklpSC3GhiqWdpYWpsDLQqJz8vHSpqaKxnYmZoVgu0LRVofU5xaFEO0D/6MPfpI3yWkVjsnppfkl9aBPdYQU5icmqKC9AyoB5QOOkamOgaWYYYmloZGAARUFd+OdBLIJdAQyogyCPQ2TEQKFNanFoEDe/cxCJgUOsVl+RnVyoB3ZKTWFzill+aBzPawMDAUBeMQsDmQowuKUpMzk5Mykl1BiotAYdBUWp6Zj4wgJQCcqpSj3YAI2uvQnZRYhY4poCKioBBqeRclZqckZkIFEssKSnKTCoFhxU0KRiZwFNBeEZqak5yRmJmkUJicnJqcXEm0C6grsxix4KCnMxkkNVKViVFpam1OhDNwEiD6g1KTc7PzU3NS0lNUUjLL1LIzkwpxqvVxBCuN7ikKD8nJxXdVpxaETpd8tPRbUFVamQKVxuQWJSdmZeukJeaWJRUia4L1VsIXZGJRSkKGgVFmWXAmFEA5qPMlNS85FRNvPqNjeD6nTKTK5NzgOGNT70pwr7gjPyiEoWMzOxUBQ0bQ4XsXHSb0HQibPLLTM8oUQAnYnQtkOQL9x0wR+CINVBizywGZll0A1DCFBHrAaVJQCUKwISZV1wAdDgw8+XnoYcwuhngEEKUPR75RcXo4YPuZGNElDsn5hagRyNObRYo2tIygfGHrgMtbBC5IaQoNVUhOSczNwlkXVFqYSlQewp+7aYI7Y5JiXkp+XnAgC0Gejy5pLQIPVpgemNrY3WUSvJLEnOUrCzNjCxrAQEAAP//Ii8TZrAFAAA=",
           "encoding": "utf-8",
           "string": ""
         },
@@ -44,16 +44,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "747"
+            "803"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "692cfbe6-881c-45e1-854a-18587a36b160"
+            "5354b842-ba77-419b-8eba-795785714be7"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:28:05 GMT"
+            "Thu, 12 Jan 2023 17:13:05 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -75,11 +75,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=0&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=0&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:28:06",
+      "recorded_at": "2023-01-12T17:13:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -99,32 +99,32 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=1&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=1&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8451438,\"name\":\"Dobr\u00e9 r\u00e1no na ho\u0159e \u0158\u00edp 2\",\"code\":\"GC9JF6Z\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":2.5,\"userFound\":false,\"userDidNotFind\":false,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.388017,\"longitude\":14.292067},\"detailsUrl\":\"/geocache/GC9JF6Z\",\"hasGeotour\":false,\"hasLogDraft\":false,\"placedDate\":\"2022-05-14T06:00:00\",\"owner\":{\"code\":\"PR4FQRZ\",\"username\":\"eMichalek\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":63,\"name\":\"Recommended for tourists\",\"isApplicable\":true}]}],\"total\":9291}"
+          "string": "{\"results\":[{\"id\":8630552,\"name\":\"Hr\u016fzopt\u00e1k\",\"code\":\"GC9RFJV\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":2,\"difficulty\":4.0,\"terrain\":4.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.69935,\"longitude\":14.28095},\"detailsUrl\":\"/geocache/GC9RFJV\",\"hasGeotour\":false,\"placedDate\":\"2022-04-17T00:00:00\",\"owner\":{\"code\":\"PR2J92V\",\"username\":\"Groot62\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":64,\"name\":\"Tree climbing required\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9629}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
           "Content-Length": [
-            "867"
+            "721"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "afdec5f6-e95d-4d9d-acf7-e866265fffe6"
+            "773b6e04-cc8d-464e-9b71-e0566b667710"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:28:05 GMT"
+            "Thu, 12 Jan 2023 17:13:05 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -146,11 +146,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=1&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=1&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:28:06",
+      "recorded_at": "2023-01-12T17:13:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -170,32 +170,32 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=2&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=2&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8547077,\"name\":\"ERIK LOUDI HRISKY\",\"code\":\"GC9NNQ3\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":2,\"difficulty\":4.0,\"terrain\":3.5,\"userFound\":false,\"userDidNotFind\":false,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.641917,\"longitude\":14.279433},\"detailsUrl\":\"/geocache/GC9NNQ3\",\"hasGeotour\":false,\"hasLogDraft\":false,\"placedDate\":\"2022-02-19T00:00:00\",\"owner\":{\"code\":\"PRTPB6J\",\"username\":\"Wassermani\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":55,\"name\":\"Short hike (<1 km)\",\"isApplicable\":true},{\"id\":51,\"name\":\"Special tool required\",\"isApplicable\":true},{\"id\":19,\"name\":\"Ticks\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9291}"
+          "string": "{\"results\":[{\"id\":8630552,\"name\":\"Hr\u016fzopt\u00e1k\",\"code\":\"GC9RFJV\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":2,\"difficulty\":4.0,\"terrain\":4.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.69935,\"longitude\":14.28095},\"detailsUrl\":\"/geocache/GC9RFJV\",\"hasGeotour\":false,\"placedDate\":\"2022-04-17T00:00:00\",\"owner\":{\"code\":\"PR2J92V\",\"username\":\"Groot62\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":64,\"name\":\"Tree climbing required\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9629}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
           "Content-Length": [
-            "798"
+            "721"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "0fcd447b-5792-466a-b8ee-d5e0548750ec"
+            "09156743-4617-41f8-bd5d-6c1d20bc33f5"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:28:06 GMT"
+            "Thu, 12 Jan 2023 17:13:06 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -217,11 +217,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=2&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=2&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:28:06",
+      "recorded_at": "2023-01-12T17:13:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -241,32 +241,32 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=3&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=3&sort=datelastvisited"
       },
       "response": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8503181,\"name\":\"S Arandurem  na kole v Dominik\u00e1nsk\u00e9 republice\",\"code\":\"GC9M723\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"userFound\":false,\"userDidNotFind\":false,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.146683,\"longitude\":14.103583},\"detailsUrl\":\"/geocache/GC9M723\",\"hasGeotour\":false,\"hasLogDraft\":false,\"placedDate\":\"2022-02-24T19:15:00\",\"owner\":{\"code\":\"PR671V8\",\"username\":\"evenTeam\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"St\u0159edo\u010desk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":28,\"name\":\"Public restrooms nearby\",\"isApplicable\":true},{\"id\":27,\"name\":\"Drinking water nearby\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true}]}],\"total\":9291}"
+          "string": "{\"results\":[{\"id\":8857038,\"name\":\"Narozeninov\u00e9 \u0161pek\u00e1\u010dky\",\"code\":\"GCA138V\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":49.862033,\"longitude\":13.76965},\"detailsUrl\":\"/geocache/GCA138V\",\"hasGeotour\":false,\"placedDate\":\"2023-02-12T10:00:00\",\"owner\":{\"code\":\"PRJW5NK\",\"username\":\"Fischi297\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Plze\u0148sk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":65,\"name\":\"Yard (private residence)\",\"isApplicable\":true}]}],\"total\":9629}"
         },
         "headers": {
           "Cache-Control": [
             "max-age=60, private"
           ],
           "Content-Length": [
-            "928"
+            "777"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "17b8c45e-708e-44e4-a676-51d87c88f522"
+            "601428c3-eb5e-4dea-b3b8-f84a2bb84e9a"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:28:06 GMT"
+            "Thu, 12 Jan 2023 17:13:06 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -288,11 +288,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=3&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=3&sort=datelastvisited"
       }
     },
     {
-      "recorded_at": "2022-02-22T16:28:07",
+      "recorded_at": "2023-01-12T17:13:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -312,15 +312,740 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.25.1"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=4&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=4&sort=datelastvisited"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNTE0MTPQUcpLzE1VslIKODrz8Nqc1ILi7MMrFZJKU7IrFYwMjIyUdJSS81NACtydLf3cwiOAAgVFqbmZpbn+eTmVSlZpiTnFqTpKaYll+UWZJakB+Zl5IFuABqen5icnJmekhlQWAPUbGoNMyitJzMxLLYIImekopWSmpWUmAx0GNMlQD6ipJLWoCKhEycoYxCstTi1yyy/NA7oXag9IxCUzxS+/xC0TSRhsUXBJYkkpxO6C/OKS1BTn/PyilMy8xJJUoGi1Uk5iSWZJKcgzpgZ6hqYmJqaWOko5+XnpUFFDEz1jA0tDU/NaoMNSgS7NKQ4tygF6XR/mFX1EIGQkFrun5pfklxbBHQEU8slPdylKTCuBixXkJCanprgAnQA0BxSgugZGukbmIYYmVgYGQAQ0Kb8cGCIg90EDOiDI0sMswgMoA/IsNHqc8rOA/k1UAjotJ7G4BBwoUFMNDAwMdcEoBGwkxNSSosTk7MSknFRnoFKge4CBUpSanpkPDFql4JKjM1NT8o/0pgJje69CdlFiFjiegQqLgBGh5FyVmpyRmQgUSywpKcpMKgUHIDThAGMN6qag1OT83NzUvJTUFIW0/CKF7MyUYqCezGLHgoKczGSQ5UpWJUWlqbU6EK0mhnC9wSVF+Tk5qUUKicnJqcXFmSC1+LQidLrkp6PbgqrU2Aiu1ikzuTI5B+h4fOpNkVxVkJqcmZijUJKfn6NQlFpYmlmUmoKuGdUyE7jmwNJEdP8DhcHpAK7aFK7aPy1Ntyg/MUWhLDUjE92N6DqBoY6wJ6QoNVUhOSczNykzL52QK6H2wjU7w/SlpyYWEdIMjTWEbp/MstTikvzkbIU8oPakSnR9qJYCcxfMyRn5RXnoPkRVbYSINQ9gOgQ5MbEoFZQGseiJrY3VUSrJL0nMUbKyNLI0rAUEAAD//2bpR+HgBAAA",
+          "encoding": "utf-8",
+          "string": "{\"results\":[{\"id\":8828409,\"name\":\"Kru\u0161nohorsk\u00fd krp\u00e1l\",\"code\":\"GCA04FA\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":8,\"difficulty\":5.0,\"terrain\":5.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.722117,\"longitude\":13.881683},\"detailsUrl\":\"/geocache/GCA04FA\",\"hasGeotour\":false,\"placedDate\":\"2022-09-23T00:00:00\",\"owner\":{\"code\":\"PR33HRK\",\"username\":\"oblac\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":56,\"name\":\"Medium hike (1 km\u201310 km)\",\"isApplicable\":true},{\"id\":44,\"name\":\"Flashlight required\",\"isApplicable\":true},{\"id\":15,\"name\":\"Available in winter\",\"isApplicable\":false},{\"id\":3,\"name\":\"Climbing gear required\",\"isApplicable\":true}]}],\"total\":9629}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "max-age=60, private"
+          ],
+          "Content-Length": [
+            "772"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "250fd485-b5bb-4ead-bbb9-f2fbba52d565"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 17:13:07 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=4&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T17:13:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=5&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"results\":[{\"id\":8917538,\"name\":\"Discop\u0159\u00edb\u011bh - FILMOV\u00c1 M\u00cdSTA\",\"code\":\"GCA347E\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.065,\"longitude\":14.30555},\"detailsUrl\":\"/geocache/GCA347E\",\"hasGeotour\":false,\"placedDate\":\"2023-02-06T17:30:00\",\"owner\":{\"code\":\"PR49M20\",\"username\":\"bumbik\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Hlavn\u00ed m\u011bsto Praha\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":33,\"name\":\"Motorcycles\",\"isApplicable\":true}]}],\"total\":9629}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "max-age=60, private"
+          ],
+          "Content-Length": [
+            "915"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "5be6301b-1975-4d45-bd07-c0031dc18b21"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 17:13:08 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=5&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T17:13:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=6&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"results\":[{\"id\":8917538,\"name\":\"Discop\u0159\u00edb\u011bh - FILMOV\u00c1 M\u00cdSTA\",\"code\":\"GCA347E\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.0,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.065,\"longitude\":14.30555},\"detailsUrl\":\"/geocache/GCA347E\",\"hasGeotour\":false,\"placedDate\":\"2023-02-06T17:30:00\",\"owner\":{\"code\":\"PR49M20\",\"username\":\"bumbik\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Hlavn\u00ed m\u011bsto Praha\",\"country\":\"Czechia\",\"attributes\":[{\"id\":24,\"name\":\"Wheelchair accessible\",\"isApplicable\":true},{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":33,\"name\":\"Motorcycles\",\"isApplicable\":true}]}],\"total\":9629}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "max-age=60, private"
+          ],
+          "Content-Length": [
+            "915"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "2f7090bd-2eee-4631-a5cf-0b739f4b0de1"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 17:13:08 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=6&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T17:13:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=7&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"results\":[{\"id\":8935788,\"name\":\"Sch\u016fze OKS 20230222\",\"code\":\"GCA3Q75\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.2363166666667,\"longitude\":14.0819166666667},\"detailsUrl\":\"/geocache/GCA3Q75\",\"hasGeotour\":false,\"placedDate\":\"2023-02-22T17:00:00\",\"owner\":{\"code\":\"PR6D6C6\",\"username\":\"ashberry\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"St\u0159edo\u010desk\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":41,\"name\":\"Stroller accessible\",\"isApplicable\":true},{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":8,\"name\":\"Scenic view\",\"isApplicable\":true},{\"id\":7,\"name\":\"Takes less than one hour\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true},{\"id\":19,\"name\":\"Ticks\",\"isApplicable\":true},{\"id\":39,\"name\":\"Thorns\",\"isApplicable\":true}]}],\"total\":9629}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "max-age=60, private"
+          ],
+          "Content-Length": [
+            "1023"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "94ffc834-2812-4e72-8c3a-58eeb7c5c9bc"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 17:13:09 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=7&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T17:13:10",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=8&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"results\":[{\"id\":8912666,\"name\":\"Vindaloo challenge 2023 - Litom\u011b\u0159ice \u201e(VCH2023)\u201c\",\"code\":\"GCA2Z59\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.533283,\"longitude\":14.135833},\"detailsUrl\":\"/geocache/GCA2Z59\",\"hasGeotour\":false,\"placedDate\":\"2023-01-27T17:30:00\",\"owner\":{\"code\":\"PRYCKKE\",\"username\":\"Tulacka2\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":32,\"name\":\"Bicycles\",\"isApplicable\":true},{\"id\":55,\"name\":\"Short hike (<1 km)\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true}]}],\"total\":9629}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "max-age=60, private"
+          ],
+          "Content-Length": [
+            "790"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "e23847e2-b526-437d-b24a-d8046085df28"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 17:13:09 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=8&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T17:13:10",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "c6ee9723-88f7-4d0b-a311-ec4c288e7758"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 17:13:09 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ],
+          "x-rate-limit-reset": [
+            "50"
+          ]
+        },
+        "status": {
+          "code": 429,
+          "message": ""
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T17:13:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "24d1c423-4fbc-4cd5-8676-40c334744fd2"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 17:13:19 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ],
+          "x-rate-limit-reset": [
+            "40"
+          ]
+        },
+        "status": {
+          "code": 429,
+          "message": ""
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T17:13:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "1528f87b-bf21-430b-b545-fadc1e4a9520"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 17:13:29 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ],
+          "x-rate-limit-reset": [
+            "30"
+          ]
+        },
+        "status": {
+          "code": 429,
+          "message": ""
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T17:13:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "2d29639b-4ed3-41cc-8e57-360de751439d"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 17:13:40 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ],
+          "x-rate-limit-reset": [
+            "20"
+          ]
+        },
+        "status": {
+          "code": 429,
+          "message": ""
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T17:13:51",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "13687b77-8dbd-40af-9ca3-b47e961d4c57"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 17:13:51 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ],
+          "x-rate-limit-reset": [
+            "9"
+          ]
+        },
+        "status": {
+          "code": 429,
+          "message": ""
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T17:14:01",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNTU0MTLUUcpLzE1VslIKyC8tyTu8NlshJV+hqqQoMTk1L1FJRyk5PwUk6+5s6RdmYQ4UKChKzc0szfXPy6lUskpLzClO1VFKSyzLL8osSQ3Iz8wDWWGgo5Semp+cmJyRGlJZANRvATIoryQxMy+1CC6SkpmWlpkMdBTQIFM9oJ6S1KIioBIoD6w9uCSxpBRiYkF+cUlqinN+flFKZl5iSSpQtFopJ7Eks6QU5ERTAz0zSzMLM3MdpZz8vHSoqKGxnoWJuYGxcS3QvlSgA3KKQ4tygB7ShzlQH+G1jMRi99T8kvzSIrjPCnKAAZHiArQOqMfIwMhI18BI18goxMDACoyAuvLLgZ4CuQUaVAFBxsYeQd5AmdLi1CJo6OYnAQ1SAjoiJ7G4xC2/NA9mpoGBgaEuGCGbCQr/7MSknFRnoNISsPeLUtMz84Fho3R4FjAckrMP71XILkrMAkcRUE0RMBCVnKtSkzMyQdGWWFJSlJlUCg4lWITDozoYGLeZyQplmanlQKWZxY4FBTmZySDrlKxKikpTa3UgOkzN4Fp8U1OAka6QkZmdqqBhqJCd+6hhsqEBkNbEa4KhCdyEoNTk/Nzc1LyU1BSFxBKFvMz0jBJ0vZBQh2k2RrjYOTG3IC0TmITx6zA0hetwLAPGNUiJQmaeQjkwWQLjCK9eM4RTQ4pSUxWSczJzkzLz0hWKUgtLgVanoGtH8aiRMVy3S2JeempRfmmxQmJRKigu8OhCZD/nHGBu0Ae6KAdsZ35yNrpf0bQCkwTMq0mJeSn5ecBwzQXmL3RdqPFhifBkJroV6IqNkRRn5BfloatGc5ARXLUHMD2CfIHuf4Se2NpYHaWS/JLEHCUrSzMjy1pAAAAA///uym57oAQAAA==",
           "encoding": "utf-8",
           "string": ""
         },
@@ -335,16 +1060,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "738"
+            "694"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "774bc92f-8e76-4f5a-8385-06a04b0a59cb"
+            "0ea3a689-0cb7-4475-9275-db05a20c6a70"
           ],
           "Date": [
-            "Tue, 22 Feb 2022 16:28:07 GMT"
+            "Thu, 12 Jan 2023 17:14:01 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -366,746 +1091,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=4&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2022-02-22T16:28:07",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.25.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=5&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNbY0MzLUUcpLzE1VslI60pOafXhhbqpCcarC0QVlqVnZqbkKeYkKZZlFJaWHF+ZklyrpKCXnp4DUujtb+rlEeQEFCopSczNLc/3zciqVrNISc4pTdZTSEsvyizJLUgPyM/NAFhroKKWn5icnJmekhlQWAPWbgQzKK0nMzEstgoukZKalZSYDnQg0yFAPqKcktagIqATEM9VRKi1OLXLLL80DuhxqDUjEJTPFL7/ELRNJGGxPcEliSSnE6oL84pLUFOf8/KKUzLzEklSgaLVSTmJJZkkpyC+mBnpGJgYWxsY6Sjn5eelQUUMTPWNDA0vTWqC7UoEOzSkOLcoBelwf5hF9RBBkJBa7p+aX5JcWwd0AFPLJT3cpSkwrgYsV5CQmp6a4AF0ANMfIwMhI18BI18gixNDcytDUysAAaFJ+OTBAQM6DBnNAkHGQq5cbUAbkV2g8eecDw7wE6BUloONyEotLwKECNdfAwMBQF4xCDAyAhkLMLSlKTM5OTMpJdQYqBboIGCpFqemZ+cCwVQouOTozNSX/SG9qcfbhvQrZRYlZ4HgGKiwCxoSSc1VqckZmIlAssaSkKDOpFByC0DQEjDaoq4JSk/Nzc1PzUlJTFNLyixSyM1OKgXoyix0LCnIyk0GWK1mVFJWm1upAtJogUl5wSVF+Tk5qkUJicnJqcXEmSC0+rQidLvnp6LagKrVAWJKcmpeZDEzNqeV4dZjDdYQkZqcWK+QAXaRQkpGYp5Cfl6qQAYplfNqNgEkVqj8gsSg7My9dIS81sSipEq8uU0u4Lrf8/BRCWsAWIcI+oDQJqEQBGMt5xQX5RcCkD4xavGbE1sbqKJXklyTmKFlZGlka1gICAAD//wS/zmofBAAA",
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Cache-Control": [
-            "max-age=60, private"
-          ],
-          "Connection": [
-            "Keep-Alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Length": [
-            "687"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "07756b8a-a559-45ff-93fc-9d22bfa80e18"
-          ],
-          "Date": [
-            "Tue, 22 Feb 2022 16:28:07 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=5&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2022-02-22T16:28:08",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.25.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=6&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8498038,\"name\":\"BOWLING V \u017dATCI 22022022\",\"code\":\"GC9M1P6\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":6,\"containerType\":6,\"difficulty\":1.0,\"terrain\":1.5,\"userFound\":false,\"userDidNotFind\":false,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.3307,\"longitude\":13.538183},\"detailsUrl\":\"/geocache/GC9M1P6\",\"hasGeotour\":false,\"hasLogDraft\":false,\"placedDate\":\"2022-02-22T18:00:00\",\"owner\":{\"code\":\"PRH0ZZ6\",\"username\":\"JaraVeve\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":true},{\"id\":25,\"name\":\"Parking nearby\",\"isApplicable\":true},{\"id\":28,\"name\":\"Public restrooms nearby\",\"isApplicable\":true},{\"id\":59,\"name\":\"Food nearby\",\"isApplicable\":true}]}],\"total\":9291}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "max-age=60, private"
-          ],
-          "Content-Length": [
-            "819"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "8fee99ed-35e7-4477-9643-21f524dac65a"
-          ],
-          "Date": [
-            "Tue, 22 Feb 2022 16:28:07 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=6&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2022-02-22T16:28:08",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.25.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8543990,\"name\":\"Ukli\u010fme okolo Motolsk\u00fdch rybn\u00edk\u016f\",\"code\":\"GC9NJGG\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":13,\"containerType\":6,\"difficulty\":1.0,\"terrain\":2.0,\"userFound\":false,\"userDidNotFind\":false,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.0679666666667,\"longitude\":14.3372166666667},\"detailsUrl\":\"/geocache/GC9NJGG\",\"hasGeotour\":false,\"hasLogDraft\":false,\"placedDate\":\"2022-04-05T17:30:00\",\"owner\":{\"code\":\"PRKHNA9\",\"username\":\"renanep\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"Hlavn\u00ed m\u011bsto Praha\",\"country\":\"Czechia\",\"attributes\":[{\"id\":1,\"name\":\"Dogs\",\"isApplicable\":true},{\"id\":63,\"name\":\"Recommended for tourists\",\"isApplicable\":true},{\"id\":26,\"name\":\"Public transportation nearby\",\"isApplicable\":true}]}],\"total\":9291}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "max-age=60, private"
-          ],
-          "Content-Length": [
-            "800"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "851db849-e88f-447e-96bf-d76128a6f791"
-          ],
-          "Date": [
-            "Tue, 22 Feb 2022 16:28:08 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=7&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2022-02-22T16:28:08",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.25.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=8&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"results\":[{\"id\":8161589,\"name\":\"Ztracen\u00e1 nad\u011bje\",\"code\":\"GC98QK0\",\"premiumOnly\":false,\"favoritePoints\":0,\"geocacheType\":8,\"containerType\":2,\"difficulty\":5.0,\"terrain\":4.5,\"userFound\":false,\"userDidNotFind\":false,\"cacheStatus\":0,\"postedCoordinates\":{\"latitude\":50.659583,\"longitude\":14.164317},\"detailsUrl\":\"/geocache/GC98QK0\",\"hasGeotour\":false,\"hasLogDraft\":false,\"placedDate\":\"2021-04-04T00:00:00\",\"owner\":{\"code\":\"PR33HRK\",\"username\":\"oblac\"},\"lastFoundDate\":\"0001-01-01T00:00:00\",\"trackableCount\":0,\"region\":\"\u00dasteck\u00fd kraj\",\"country\":\"Czechia\",\"attributes\":[{\"id\":6,\"name\":\"Recommended for kids\",\"isApplicable\":false},{\"id\":56,\"name\":\"Medium hike (1 km\u201310 km)\",\"isApplicable\":true},{\"id\":47,\"name\":\"Field puzzle\",\"isApplicable\":true},{\"id\":14,\"name\":\"Recommended at night\",\"isApplicable\":false},{\"id\":51,\"name\":\"Special tool required\",\"isApplicable\":true},{\"id\":11,\"name\":\"May require wading\",\"isApplicable\":true}]}],\"total\":9291}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "max-age=60, private"
-          ],
-          "Content-Length": [
-            "941"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "c341b15b-b511-4210-9f57-343c06609d7e"
-          ],
-          "Date": [
-            "Tue, 22 Feb 2022 16:28:08 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=8&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2022-02-22T16:28:09",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.25.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "private"
-          ],
-          "Content-Length": [
-            "54"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "6cd00671-72f7-4151-8e41-bad2702f166d"
-          ],
-          "Date": [
-            "Tue, 22 Feb 2022 16:28:08 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ],
-          "x-rate-limit-reset": [
-            "51"
-          ]
-        },
-        "status": {
-          "code": 429,
-          "message": ""
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2022-02-22T16:28:19",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.25.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "private"
-          ],
-          "Content-Length": [
-            "54"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "e570fb61-928e-40f1-9c28-93fee1223a3b"
-          ],
-          "Date": [
-            "Tue, 22 Feb 2022 16:28:19 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ],
-          "x-rate-limit-reset": [
-            "41"
-          ]
-        },
-        "status": {
-          "code": 429,
-          "message": ""
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2022-02-22T16:28:29",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.25.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "private"
-          ],
-          "Content-Length": [
-            "54"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "d59842d9-6ac8-49c2-b8aa-02c4fc043a9e"
-          ],
-          "Date": [
-            "Tue, 22 Feb 2022 16:28:29 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ],
-          "x-rate-limit-reset": [
-            "31"
-          ]
-        },
-        "status": {
-          "code": 429,
-          "message": ""
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2022-02-22T16:28:39",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.25.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "private"
-          ],
-          "Content-Length": [
-            "54"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "a17a09a6-3899-43b6-8537-25082f9ad688"
-          ],
-          "Date": [
-            "Tue, 22 Feb 2022 16:28:39 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ],
-          "x-rate-limit-reset": [
-            "21"
-          ]
-        },
-        "status": {
-          "code": 429,
-          "message": ""
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2022-02-22T16:28:49",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.25.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "private"
-          ],
-          "Content-Length": [
-            "54"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "4b307853-a9b5-43cc-8a20-28f6d351fc95"
-          ],
-          "Date": [
-            "Tue, 22 Feb 2022 16:28:49 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ],
-          "x-rate-limit-reset": [
-            "11"
-          ]
-        },
-        "status": {
-          "code": 429,
-          "message": ""
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
-      }
-    },
-    {
-      "recorded_at": "2022-02-22T16:29:00",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.25.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwNTYzMTLXUcpLzE1VslLyLso/0puakZNYVpx9eKWCu6t/QWZZvoKxwof5vbtgWElHKTk/BaTc3dnSz9HXAyhQUJSam1ma65+XU6lklZaYU5yqo5SWWJZflFmSGpCfmQey00BHKT01PzkxOSM1pLIAqN8MZFBeSWJmXmoRXCQlMy0tMxnoSqBBhnpAPSWpRUVAJVBeaXFqkVt+aR7Q8VBrQCIumSl++SVumUjCYHuCSxJLSiFWF+QXl6SmOOfnF6Vk5iWWpAJFq5VyEksyS0pBfjE10DM0sjA3NtZRysnPS4eKGproGRqaGZrWAt2VCnRoTnFoUQ7Q4/owj+gjgiAjsdg9Nb8kv7QI7gagkE9+uktRYloJXKwgJzE5NcUF6AKgOUYGRka6Bsa6hgYhhhZWBgZABDQpvxwYICDnQYM5IMjRzd0pBCgD8is0qioTi/JLizNSs5WAjstJLC4BhwrUXAMDA0NdMAoBGwoxt6QoMTk7MSkn1RmoFOgiYKgUpaZn5gPDVim45OjM1BRQ7ANjfq9CdlFiFjiegQqLgDGh5FyVmpyRmQgUSywpKcpMKgWHIDQZGZnAU1B4RmpqTnJGYmaRQmJycmpxcSbQPqCuzGLHgoKczGSQ9UpWJUWlqbU60DQI1xucnJqXmaxQlplajq4DEnowLUamcD0BiUXZmXnpCnmpiUVJlejaUCwyNoLrcspMrkzOAfoAn3ojhMsCSpOAShSA2aekKD8/txjdOmzaTS3h2t3y81MIaQHbCEz/qDYCoyyvuCC/CJiOgfFEyAywtQhXu5Wm5hDSAg4YQ7gW58TcAvTgRI8FuDaETSBtaZnA4EHXgRZviCAJSc1JLcjIz0tFtwqrRjNE1AWnJhbn5yXmQJMXuj40JyICNDgvvzw3PykTPdbR9ViZIRJzSFFqqkJyTmZuEihMilILS4F+TMGv3RSh3TEpMS8F6MUUBWCyKU0uKS1Czwloeg0RJTGw0AR6E5jDFYAFBqj4xK4xtjZWR6kkvyQxR8nK0sjSsBYQAAD//0n5eEfkBQAA",
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Cache-Control": [
-            "max-age=60, private"
-          ],
-          "Connection": [
-            "Keep-Alive"
-          ],
-          "Content-Encoding": [
-            "gzip"
-          ],
-          "Content-Length": [
-            "813"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "b9c82b1c-29d7-4038-a1a3-a5175ebe04e7"
-          ],
-          "Date": [
-            "Tue, 22 Feb 2022 16:28:59 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=true&skip=9&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=50.74%2C13.38%2C49.73%2C14.4&take=1&asc=True&skip=9&sort=datelastvisited"
       }
     }
   ],

--- a/test/cassettes/geocaching_search_rect.json
+++ b/test/cassettes/geocaching_search_rect.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2021-11-14T01:39:04",
+      "recorded_at": "2023-01-12T18:36:09",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -21,7 +21,7 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.26.0"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
@@ -29,7 +29,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjI0sjC1NDPQUcpLzE1VslLyzs9LTc5LVCgrTk3OUCgpSswtS8zKVNBVKMuvyi/LS1TSUUrOTwGpdHc2DImMdAcKFBSl5maW5vrn5VQqWaUl5hSn6iilJZblF2WWpAbkZ+aBrDPXUUpPzU9OTM5IDaksAOq3ABmUV5KYmZdaBBEx0lFKyUxLy0wGOhBokLEe0FUlqUVFQCVAd+qZ6iiVFqcWueWX5gHdDbUGJOKSmeKXX+KWiSQMtie4JLGkFGg10JiC/OKS1BTn/PyilMy8xJJUoGi1Uk5iSWZJKcgvJpZ65sbmBhbGOko5+XnpUFFDYz1jCwOTWqCzUoHuzCkOLcoB+lsf5g99RAhkJBa7p+aX5JcWwZ0AFPLJT3cpSkwrgYsV5CQmp6a4AB0ANMfIwMBS18BM18g4xMDACoyAJuWXA8MD5DpoKAcEmQYG+XkAZUBehUaSo49PprdCSWpirhLQdTmJxSXgUIEbbGSoa2Cia2AYYmgENbhWBxLdZmaGxqbmwLCHmhTgq6BsaqEQkFiQWZSaV5yNEr/mXkFBpkTGryWh+AWLIMevCUr8GtE6fo3NLA2BiRA9fk0MzczxxTAsDEiNYUhEGFroGhjpGpnij2ETc8vIINQYDspMDnENwB27FrqGRthi19jI0gCRmUGxa2Kq4AsMHYUP83s6USLX2yXclcjINTEjNXbRcq8piEfT2DUwQc+9oNg1NDfFG7nQMCA/co11DQ3xR66Le4CXC2rkVqWkZiRm4YxcQwNdA0sskWtpZG5kCI9bj3xQYCjkAjUCcWZ2JUrJbGboDUpRxESuITDcCEUuetEMyqzoRTMNI9fSHD3rgiLX3NTCGD12UQpnaCCQGruQiDAwB8aCrqEF/tg1svAKN0ON3ZTUrDRzU3yxa2SCHrsgf5oYGyJybpS/v4JnUWYxcqRGOZuCEhKhOEWvbWERiJ5fUaMUHIl0jFITI2P0/AqqbQ0N0UtjlCiFBgGZMWoGzKyEYjTI0CTCLBA1Rn0zkzMSc4IV1BTccvLLgepxxi2wZAZWugZWxoZWxmbwuDU0MDQ1NAN6F2qee2VuZjZKdnUPNzUhFLWwshg9atFzKzB7okatEVpFi14UUztqLdErWkhuNUaPWrTcCg0DMuMWWCECi030ihY9t5o5R3qjxq1XKtBDRZl4oxQ9uwKDx9TMxNAAmEdgFW1OFaj1lApsMOfnpGYllRajFseGAUHhRMYv0FDU+AXGJqHSGD3rUjt+0RrKwCYTevwCs64lekMKLX6hYUBm/AJLY2NdI3P0+EXLu84G4OY4UvyWlaZU4o1c9JoWGDYWwKLC1BIRu96JuQqJR/cpFCdmHF6oAIrrox32yPFraezhCKoFUOK3pKgUPXqBoWmEXtui51+ICHpTCjl+0fMvKfGLM3pgXiA1eqBhaQBsj6JnP/ToCTJ2NAwEySBFj0tqXl7l0YWHF2bHJ8Y7JQK9iyeuDA2Q4ipWR6kkvyQxR8nKohYQAAD//34SCunXDgAA",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwsDQyNzHTUcpLzE1VslJyT80PO7y3qixRQVfBO7EoNUchIDEn9UhvaraSjlJyfgpYjbOjkaVLAFCgoCg1N7M01z8vp1LJKi0xpzhVRyktsSy/KLMkNSA/Mw9kkYGOUnpqfnJickZqSGUBUD/QsuT8vJLEzLzUIrhISmZaWmYy0GlAgwz1gHpKUouKgEqgPLD24JLEklKIiQX5xSWpKc75+UUpmXmJJalA0WqlnMSSzJJSkBNNLPXMjS0tjYAG5+TnpUNFDY31jC0sDS0ta4H2pQIdkFMcWpQD9JA+zIH6CK9lJBYDw6Ikv7QI7rOCnMTk1BQXoHVAPUYGRsa6Boa6RhYhhqZWBgZABNSVXw70FMgt0KAKCHJ2dg9zBsqUFqcWQcM4JTMls7RYD2hqcr4S0C05icUlbvmleTCjDQyA5oJRCNhciNElRYnJ2YlJOanOQKUl4FAoSk3PzAcGkVJATlXq0Y7i7MN7FbKLErPAUQVUVAQMTCXnqtTkjMxEoFhiSUlRZlIpOLSg0W9kAo/58IzU1JzkjMTMIoXE5OTU4uJMoF1AXZnFjgUFOZnJIKuVrEqKSlNrdSCaEakmKDU5Pzc3NS8lNUUhLb9IITszpRivVhNDuN7gkqL8nJxUdFvRtabWxsI0GxoYmhqaGSPSbGVuJkryNHQPNzUhMnkCAwA1eVqgJ08roE3IydMIJXmCeeQlT0Nz9ORpbGFubGiOL3nCvEYoeRoZGFjoGhroGpgipyH05BkQZGTmHOmNmjy9UoGOL8pET5kQU42MdA2NdA1MQgyNBjploqURcCgQSl/oetGTJih1wXW65Kejp2I0pYg06FgGjC+QCgUjE31zvLqMTOG6AhKLsjPz0hXyUhOLkirx6jI2gutyykyuTM4BhhW6ehS3IcIPOXcmlijkZaZnlODXi3Ahwl+ZeQrlwCwDTD/oWlFzp5mZobGpOTAXwfzoq6BsagGsRgoyi1LzirNB8Q3PqeZeQUGmROZUS0I5FSyCnFNN0HIq0Fvk5FQzrDnVxNAMb06FeY1QTjUyMLTQNTDSNSKQU03MLSODUHNqUGZyiGsAekaFGEq3jEqoFsCXTdHzGnrCQs9r6GkSPa+h26BkBYw4qK6QxOzUYgVgtilWKMlIzFPIz0tVyADFCrp+ZFtNETkhOCO/qEQhIzM7VUHDxlAhO1cTXSdqDQcMXHgJlJqYU5KhUJRaWArMAyno+lD9CUzmMBdnJmejBwp6bjMzMzayNEDYBcptJqYKvsBkrfBhfk8nSmbzdgl3JZTZYNUiodwGEUHObcYouc0UvV4klNuABoJzm4GJBTCq0XObobkp3swG9Rpxmc1Y1xClaYWe2QKCXNwDvFxQM1tVSmoGMF/QO7Oh14rwmEavFdFrNvTMgJ7d0FMWqdkNXRehSgpdPTj1IrwTUpSaqpCck5mbBKoQ0bMKum6IbXDNzjB96cCKFF0zetaBWw7s+RghgsQjH5QmFXKBcQrEmdmg6hjRojQz9AYVvsRkHVDQEco6wHBCzTrAcgapx4NeURHKOrAmpTl6RQVuUppaGKPnHZQmJdRvhPIOsElprmtgqWtogZ530JqUFl7hZqh5JyU1K83cFD3vQAyF5h1TWucdKxNE4vRLTU0pBkY1qD2Tl5iXjJ5v0BpshDIdumaUJA7XS6h6RNdKqBGLrhUl+6LndHSlpOZ0dF2EGrHougiVD+jqoSFAqBJF1wezB+EnX2CKLkK3Cl0LKBjQ27ygYEBv86IXJXB3WpoYGyLcGuXvr+BZlAmyEF6CRDmbgioUYgoQYB5GLT+AoYZe9aKPmFCl/DAxAgUcevlhYIjeJUUtP6A+I6L4MAPWu4SKjyBDkwizQKAMUvHhmwnMcjnBCmoKbjn55UD16AUJ2HhIQWJkNtAFCXpCQS8LQPoIlQXoWgmVBehaCZUF6EoJlQV4dZHaxkbTjl4ooOdUdPWECgV0fYhsampmYmiAVHABEwCwQ5qqAArQ1Kyk0mLUOt8wICicyCwLNBQ1ywIDklCVT5Usaw7shWLJspbofVO0Kh/qNUJ5FlLlG+samRPIs84Gke6oebasNKUSPZ9CjKR3PgXZip5P0XMMqdkAXRep2QCqHaV1DhqthqXM0iSgGmC6TMwrLgB2O4Fxnp+HXsGipfFYHaWS/JLEHCUr81pAAAAA//+jYN256BcAAA==",
           "encoding": "utf-8",
           "string": ""
         },
@@ -44,16 +44,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "1164"
+            "1672"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "bc323d9e-281b-4859-b3ba-b3f635b5abfa"
+            "f2106903-82f9-4a97-9445-68fbd1d03018"
           ],
           "Date": [
-            "Sun, 14 Nov 2021 01:39:04 GMT"
+            "Thu, 12 Jan 2023 18:36:08 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -79,7 +79,7 @@
       }
     },
     {
-      "recorded_at": "2021-11-14T01:39:05",
+      "recorded_at": "2023-01-12T18:36:09",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -99,7 +99,7 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.26.0"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
@@ -107,7 +107,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjI1MzE0MNVRykvMTVWyUgrIqUrNK85OVSgpys9JzUoqLa5U0lFKzk8BSbo7GxoGBIUDBQqKUnMzS3P983IqlazSEnOKU3WU0hLL8osyS1ID8jPzQBYADU1PzU9OTM5IDaksAOo3BhmUV5KYmZdaBBEx0lFKyUxLy0wGOglokLEeUE9JalERUImSlSGIV1qcWuSWX5oHdCnUGpCIS2aKX36JWyaSMNie4JLEklKg1QZAF+YXl6SmOOfnF6Vk5iWWpAJFq5VyEksyS0pBfjGx1DM3Njc0M9dRysnPS4eKGhrrGVsYWJqZ1wIdlgp0aU5xaFEO0Of6MJ/oI8IgI7HYPTW/JL+0CO4IoJBPfrpLUWJaCVysICcxOTXFBegEoDlGBgbmugbGukbmIQYGVmAENCm/HBgiIPdBwzkgyNDZINIdKAPyLDRmykpTKpWA7spJLC4BhwjcSCNDXUNDXQPLEEMjqJG1OpDINTSyMLU0A4YG1Azv/LzU5LxEhbLi1OQMYBQn5pYlZmUq6CqU5Vfll+UlokR1SCTYCcRENTAUUaPaglBUG+sBXUXPqDawACY/9Kg2MMEb0dAQIDOiLXUNzHSNjPFHtGlgkJ8HakQ7+vhkeiuUpCbm4oxuAxNdA0P06FayMjMzNDY1B4Y9LDP7KiibWigEJBZkFoFyNUr8mnsFBZkSGb+WhOIXLIIcvyYo8WtE6/g1NrM0RM/KwPg1AWZwfDEMCwNSYxgSEYYWugZGukam+GPYxNwyMgg1hoMyk0NcA3DHroWuoRF67IL8aWJsiMjLUf7+Cp5FmcXIcRrlbOpCKErRsywsSoEZFH+UgjMpepalYZSaGBljy7KGhnijFBoEpMYoJPCBGRZYkhpaoMcoWuFsEmEWiBqjvpnJGYk5wQpqCm45+eVA9bjiFlRQA3OugZWxoZWxGTxuLYBWm1oiqmHvxFyFxKP7FIoTMw4vVABVykc77JFj2tLYw9EMPapLikrRYxoYsEbAUETPvQSiGr10BvLIjmqcMQXzAqlRBQ1LA2Am0TVAz3xoUWXsaBgIkkGKKpfUvLzKowsPL8yOT4x3SgR6F09cGRqg50NgcBgYmhqaAQMVaqB7ZW5mNnLcGLqHm5qgxw16NoRGjgmhuAE3m5DjxgitZCU1bkjNhpboJSs4G5obo2dDtLoTGgakRi4k8EEloAGhyA0yMnOO9EaNXK9UoIeKMvFFqYEJepQCK05LI3MjQ3iMeuSDgkMhF6gRiDOzUZvAZobeoPKcmNg1RM966NELFEFvGKGXsrSOXnOs0WtqYYw3eqGBQGb0AtvAlujFLHr0BhlZeIWDygek6E1JzUozN8Uduwa6RuixC24WGRtZGiBqTlCzyMRUwRcYOgof5vd0IseuubdLuCuh2IXlXTNCsUugYDVFz7zUjl1jAxP0Zi8odg3NTdEjF6VVBA0DUiMXEg+gVpExMKPhj1wX9wAvUD2NFLlVKakZiVn4IhelixOro1SSX5KYo2RlUQsIAAD//wrhlKrXDgAA",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjI1MzE0MNVRykvMTVWyUgrIqUrNK85OVSgpys9JzUoqLa5U0lFKzk8BSbo7GxoGBIUDBQqKUnMzS3P983IqlazSEnOKU3WU0hLL8osyS1ID8jPzQBYADU1PzU9OTM5IDaksAOo3BhmUV5KYmZdaBBEx0lFKyUxLy0wGOglokLEeUE9JalERUImSlSGIB9YeXJJYUgo00QBocX5xSWqKc35+UUpmXmJJKlC0WiknsSSzpBTkRBNLPXNjc0Mzcx2lnPy8dKioobGesYWBpZl5LdC+VKADcopDi3KAHtKHOVAf4bWMxGL31PyS/NIiuM8KchKTU1NcgNYB9RgZGJjrGhjrGpmHGBhYgRFQV3450FMgt0CDKiDI0Nkg0h0oU1qcWgQN3LLSlEoloBtyEotL3PJL8xBGGhnpGhrpGpmFGBrBjSwpSkzOTkzKSXUGKi0B+74oNT0zHxg04Gg62lGcfXivQnZRYhY4ioCKioCBqORclZqckZkIFEssKSnKTCoFhxI0uk2AQQ51jV9qakqxQi4wrEtS8xLzklOBOjKLHQsKcjKTQdYqWZUUlabW6kA0GgJjD6rRsQwYgiAVCkYm+uZ4dQHjAaopJDE7tVghJ7W4WKEkIzFPIT8vVSEDFMjo2sFhDtNvZIZImaVJQDXAdJmYV1yQXwRMEsCgUMhLTSxKAiVRLG6IBaWu4hKw16yUPFKLQD5MAmrIzEsHCgBjAmKJmZmhsam5BcImXwVlUwuFgMSCzCJQZgAFJTwHmHsFBZkSmQMs0XMA0A60HAAUQc4BJnrAWIbnACNScwDQQHAOMLM0xJIDTID5Al8OgHmNUA4wMjC00DUAJldT/DnAxNwyMgg1BwRlJoe4BqDnAYihkDxgYELrPGCFSFNBqcn5ubmpeSmpKQpp+UUK2ZkpxehpCTVBGsL1uuSno6slNceg20BqlkG3FVyeI8ry4AxgNlHIyASW5ho2hgrZuZp4dZoAAxemsyQ1MackQ6EotbAUmAdS0PWh+hOYzGEuzkzORg8UrJnRQM8wNxMlN7rCs6OJpYmxIcItUf7+Cp5FmSBj4ZkwytnUhcg8CAxO1DwILADx50FwvYNeC5GaB82NTYyMgQkAPQ8aGBrizYNQnxHKgsBKyEzX0FDX0AI9C6JVQiYRZoGoWdA3MzkjMSdYQU3BLSe/HKgePTOCjUevkKidGdErJJCthCok1GRHKBeja0VO6YhcHAxq5+SkFikkJicDM1omSC26VpTEjp7/0ZWSmv/RdZGa/dG0GyOC0ykzuTIZqB1dPamZHn8+NkLLx8HwfGxoYGhqaIYIBPfK3MxscMKANSbdw01NgALEZGMT9GyMXpWCm5fI2dgIrSoF8sjJxpboVSk4G5sbo2djtMYk1GtE5GMLXUMDXQP0qhQtHxuZOUd6A2WQ8rFXKtDxRZno2RdiKnpdSrPsawSMGKiDwjNSU3OAZUsmembCXdcRyojoCZBQRkRXSigj4tNlhNQpSizKBqZu9MYmui5C+Q9dPdhtiPBDLsYSSxTyMtMzSvDrRbgQ4a/MPIVyUAGKXkzgyL7GaNnXD1EPm1kamRshgtkjH5RJgMVzSSoQZ2aj9gvNDL1BTT1isjIoOgjlZfSOIXqVTGZeNseal00tjPHmZajfCOVlSMfQEr1ORs/LQUYWXuFmQBmkvJySmpVmboqelSGGQrOyKa2zMqGaGD0xIeUUQmUAumb0ahw9/aNX4+haCZUe6Laia0UvPdCVopce6LkMvfRA10Wo9EDXhV56gHShlx7o6iEhQKj2RtcHswfhJ19gii5CtwpdC60LG2ARYAEsbUwQiQGY08IO760qS1TQVfBOLErNAXbHc1KP9KaitCAcjSxdAoACxBQ7wKBCLXWAlqGVOkAR1I4AcgsCzCO11IG0IECjGOiljqWhpSW+UgfmNUKlDrCAMNY1MNQ1sggxNMVT6jg7u4c5A2WQS53MlMzSYj2gqcn56GUPOMIMgOaCEXKBRu2yh1ARgp6Z0ZMmoSIEXSuhIgTdVnSt6KlazwQ9VSNVoWbGRpYGiEwKGlkyMVXwBaYahQ/zezqR07K5t0u4K6G0DGsNo48soVehEBHUKhQ5MZuSmpiBBoITs4GJBXqvFpiYDc1N0dMyysAS1GuE0jJkYMkY2LFFr0FR07KLe4AXqJeMlJarUlIzgAkOPRWDDUVvDNM6FYNsRU/F2NMT+tASep2EnvbQ6ySgWvQ6CV0XodoFXT1yvkJ4J6QoNVUhOSczNwlUk6HXMei6IbbBNTvD9KUD8wi6ZgKZyxS9e6lUG6ujVJJfkpijZGVeCwgAAP//FMizLdAYAAA=",
           "encoding": "utf-8",
           "string": ""
         },
@@ -122,16 +122,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "1170"
+            "1775"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "381dccda-016a-43b3-888e-8e45e37cfc46"
+            "4528cd20-ee34-425f-995a-7282e59ce5c7"
           ],
           "Date": [
-            "Sun, 14 Nov 2021 01:39:04 GMT"
+            "Thu, 12 Jan 2023 18:36:08 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -157,7 +157,7 @@
       }
     },
     {
-      "recorded_at": "2021-11-14T01:39:05",
+      "recorded_at": "2023-01-12T18:36:09",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -177,142 +177,45 @@
             "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.26.0"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/seek/cache_details.aspx?wp=GC93HA6"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=false&skip=0&sort=distance&origin=49.73717%2C13.38097"
       },
       "response": {
         "body": {
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjIzMzayNDDQUcpLzE1VslIK8FVQNjFV8M0vLlH4ML+nU0lHKTk/BSTj7mzu7RLuChQoKErNzSzN9c/LqVSySkvMKU7VUUpLLMsvyixJDcjPzAMZb2Kpo5Semp+cmJyRGlJZADTAAmRSXkliZl5qEVwkJTMtLTMZ6CKgScZ6QGeUpBYVAZUoWZmCeGDtwSWJJaVAI4H8AqCzUlOc8/OLUjLzEktSgaLVSjmJJZklpSA3mljqmRsbmFgY6yjl5OelQ0UNjfWMLQzNTWuB1qUC7c8pDi3KAXpIH+Y+fYTXMhKL3VPzS/JLi+A+K8hJTE5NcQHaBtRjZGBooWtgrGtoGGJgYAVGQF355UA/gZwCDaqAIBf3AC8XoExpcWoRNGSrUlIzErOUgK7ISSwuccsvzUMYamSka2ika2ASYmgEN7SkKDE5OzEpJ9UZqLQE7P2i1PTMfGDYKAXkVKUe7SjOPrxXIbsIaCgoaIGKioChqORclZqckZkIFEssKSnKTCoFBxM0uo1M4DEdnpGampOckZhZpJCYnJxaXJwJtAuoK7PYsaAgJzMZZDU0EGp1ILoN4Zpd8tOL0dValRSVIpQC4wCq1rEMGOYgFQpGJvrmeHUZG8F1OWUmVybnAJ2OT70ZwjshRampCsk5mblJmXnpCkWphaWZRakp6LpRbYNrdobpS09NLCKgORaUaotLEvOSQToN9ExzM4EKk4AagQYARYKBUQwx38LC0sjcxAxuCzBlhR3eW1WWqKCr4J1YlJqjEJCYk3qkNzUbOZc5Glm6BBCZy4BpAjWTAS1Dy2RAEeRMZoiSycA8cjKZpaUR0GD0TGZpaGmJL5fBvEYolwEzhLGugaGukUWIoSmeXObs7B7mjJrLUjJTMkuL9YCmJuej5zVwfBkAzQUj5Aw80HkNPW2Cow2qNyg1OT83NzUvJTVFIS2/SCE7MwU9U6BqNUFk0+CSovycnFR0W9G1oidqAz0TtETt5wpP1WbARG2EsMIjH5RKFHKBwQvEmdmVyGnZ0MzQO4jItAwqMdBrDPTEDCweUGsMU5TEDOSRlZjNDc3RE7OxhbmphTG+xAzzG6HEbGRgYK5rYKlraIFeZaAmZiMLr3AztMScmpVmboqejCGGQqsMU/Qqg9rJ2MoEUSb7paamFAOjGhhhqXngtIKemJDTIaH0j66Z1PSPrpVQ+ke3FV0regWHbgupFRy6LnCYAJMoVFdAYlE2qMrJA2ayJFCuQdeFXi2CdaFXi+jqISGAaM8Fl6Qm5pRkoNdp6Pqg9iD85AtM0UXoVqFrAQUDwkOIYMjMUygHpZEidK3ohQ1Im4GeMe7CxtDA0NTQDOEs98rcTJTa0tA93NQEKECohAG3SQkVMOAmAXIBY4RSW4J5pBYwkNoSawFjbGiOt4CBeo2IAsZC19AAVBbgL2DMnCO9gTJIBYxXKtDxRZnoJQzEVPRGKbVLGPSKEmQrekGBnmUhqQilUUoou6OnQELZHV0poeyOrovU7I6uCz27o+dBdPVAtyHCD7mwTCxRyMtMzyhB14uef9H9hZ5/0bWSkn9NLE2MDRGlUZS/v4JnUSbIO/AcHOVsCuopEZOBgZkINQMDAwq9T4ne3EVvIZCVgU2MQEUjegY2MMSfgaE+IyL/mgE7lOgNBPT8G2RoEmEWCJRByr++mcC8khOsoKbglpNfDlSPnpHBxkMyspEZrTMyoaYCelJCpEJCtT26VuS6jlD2R9eKnv1BOtGzP7pSQtkfhy5geoVqCknMTi1WAGbkYoWSjMQ8hfy8VIUMUIpA106oHEBXjxIUhKp9dH3oGdkIvSuLaPSbGRqbmgMzF6w0Aw4TmVoA+68FQNPzirNBCQIxTuQVFGQKFCAmS6MPE6HXyRAR5CxtglYnk5mlzdDrZHCWNjE0Q8/SqONEUK8RytOQcSJgpkOvk9HytIm5ZSSoE4GUp4Myk0NcA9BzMsRQ9CqZ2jkZMSxIKEOiV8joo0To2Qo9xRLKVui6UGwgNV+h2WqKqPOCM/KLShQyMrNTFTRsDBWyczXRdZKaw9D1QfwJTOYwF2cmZ6MHCo7saIiWHRHVqqmZiaEBUtsCGM3ATJiqACoAU7OSSotRe+GGAUHhROZHoKGo+REYQ4Q64ehVLFn50RyY89DzI7CKtUTPj2htZKjXCOVHSCfcWNfIHD0/otWxzgaR7qj5saw0pRI9N0KMRK9XqZ0b0etVkK3o9Sp6DUdq/kLXRWr2Qs+eIP2goUFYyixNAqoBpsvEvOICYFYDxnl+HnobGE8m8EgtAvkQkQeUamN1lErySxJzlKzMawEBAAD//yaguyHQGAAA",
           "encoding": "utf-8",
-          "string": "<html><head><title>Object moved</title></head><body>\r\n<h2>Object moved to <a href=\"https://www.geocaching.com/geocache/GC93HA6_kam-az-saha-plze\">here</a>.</h2>\r\n</body></html>\r\n"
+          "string": ""
         },
         "headers": {
           "Cache-Control": [
-            "no-cache"
+            "max-age=60, private"
+          ],
+          "Connection": [
+            "Keep-Alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
           ],
           "Content-Length": [
-            "177"
+            "1773"
           ],
           "Content-Type": [
-            "text/html; charset=utf-8"
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "f5fbc701-8368-408d-8868-53247e2a4f35"
           ],
           "Date": [
-            "Sun, 14 Nov 2021 01:39:05 GMT"
-          ],
-          "Expires": [
-            "-1"
-          ],
-          "Location": [
-            "https://www.geocaching.com/geocache/GC93HA6_kam-az-saha-plze"
-          ],
-          "Pragma": [
-            "no-cache"
-          ],
-          "Request-Context": [
-            "appId=cid-v1:019d82c2-5dd7-44cb-aa94-01e052f0d40c"
-          ],
-          "Server": [
-            "Microsoft-IIS/8.5"
-          ],
-          "Set-Cookie": [
-            "gspkauth=<AUTH COOKIE>; domain=.geocaching.com; expires=Tue, 14-Dec-2021 01:39:05 GMT; path=/; secure; HttpOnly",
-            "Culture=en-US; path=/; secure; HttpOnly"
+            "Thu, 12 Jan 2023 18:36:09 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
           ],
           "Vary": [
             "Accept-Encoding"
-          ],
-          "X-AspNet-Version": [
-            "4.0.30319"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ]
-        },
-        "status": {
-          "code": 301,
-          "message": "Moved Permanently"
-        },
-        "url": "https://www.geocaching.com/seek/cache_details.aspx?wp=GC93HA6"
-      }
-    },
-    {
-      "recorded_at": "2021-11-14T01:39:05",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>; Culture=en-US"
-          ],
-          "User-Agent": [
-            "python-requests/2.26.0"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/geocache/GC93HA6_kam-az-saha-plze"
-      },
-      "response": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "\n\n<!DOCTYPE html>\n<html lang=\"en\" class=\"no-js\">\n<head id=\"ctl00_Head1\">\n    <script id=\"Cookiebot\" src=\"https://consent.cookiebot.com/uc.js\" data-cbid=\"1abe029a-a5e6-4587-acc9-7ef16e95bfa1\" data-blockingmode=\"auto\" type=\"text/javascript\"></script>\n    <meta charset=\"utf-8\" /><meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge,chrome=1\" /><title>\r\n\tGeocaching > Hide and Seek a Geocache > Premium Member Only Cache\r\n</title><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" /><meta name=\"DC.title\" content=\"Geocaching&#32;-&#32;The&#32;Official&#32;Global&#32;GPS&#32;Cache&#32;Hunt&#32;Site\" /><meta name=\"twitter:card\" content=\"summary_large_image\" /><meta name=\"twitter:title\" content=\"Geocaching:&#32;Join&#32;the&#32;world&#39;s&#32;largest&#32;treasure&#32;hunt.\" /><meta name=\"twitter:description\" content=\"There&#32;are&#32;millions&#32;of&#32;geocaches&#32;worldwide&#32;and&#32;probably&#32;even&#32;some&#32;near&#32;you&#32;right&#32;now.&#32;Visit&#32;Geocaching.com&#32;to&#32;see&#32;just&#32;how&#32;many&#32;geocaches&#32;are&#32;nearby&#32;and&#32;to&#32;get&#32;the&#32;free&#32;Official&#32;Geocaching&#32;app.\" /><meta name=\"twitter:image:src\" content=\"https://www.geocaching.com/play/Content/images/preview-lg.jpg\" /><link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/apple-touch-icon.png\" /><link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"/favicon-32x32.png\" /><link rel=\"icon\" type=\"image/png\" sizes=\"16x16\" href=\"/favicon-16x16.png\" /><link rel=\"manifest\" href=\"/manifest.json\" /><link rel=\"mask-icon\" href=\"/safari-pinned-tab.svg\" color=\"#02874D\" /><link rel=\"shortcut&#32;icon\" href=\"/favicon.ico\" /><meta name=\"msapplication-config\" content=\"/browserconfig.xml\" /><meta name=\"theme-color\" content=\"#ffffff\" /><meta id=\"ctl00_ogUrl\" property=\"og:url\" content=\"http://www.geocaching.com/\" /><meta name=\"author\" content=\"Geocaching\" /><meta name=\"DC.creator\" content=\"Geocaching\" /><meta name=\"Copyright\" content=\"Copyright (c) 2000-2021 Groundspeak, Inc. All Rights Reserved.\" /><!-- Copyright (c) 2000-2021 Groundspeak, Inc. All Rights Reserved. --><meta name=\"description\" content=\"Geocaching&#32;is&#32;a&#32;treasure&#32;hunting&#32;game&#32;where&#32;you&#32;use&#32;a&#32;GPS&#32;to&#32;hide&#32;and&#32;seek&#32;containers&#32;with&#32;other&#32;participants&#32;in&#32;the&#32;activity.&#32;Geocaching.com&#32;is&#32;the&#32;listing&#32;service&#32;for&#32;geocaches&#32;around&#32;the&#32;world.\" /><meta name=\"DC.subject\" content=\"Geocaching&#32;is&#32;a&#32;treasure&#32;hunting&#32;game&#32;where&#32;you&#32;use&#32;a&#32;GPS&#32;to&#32;hide&#32;and&#32;seek&#32;containers&#32;with&#32;other&#32;participants&#32;in&#32;the&#32;activity.&#32;Geocaching.com&#32;is&#32;the&#32;listing&#32;service&#32;for&#32;geocaches&#32;around&#32;the&#32;world.\" /><meta http-equiv=\"imagetoolbar\" content=\"no\" /><meta name=\"distribution\" content=\"global\" /><meta name=\"MSSmartTagsPreventParsing\" content=\"true\" /><meta name=\"rating\" content=\"general\" /><meta name=\"revisit-after\" content=\"1&#32;days\" /><meta name=\"robots\" content=\"all\" /><meta name=\"p:domain_verify\" content=\"107f8f596a30ff1ea307df82db696a5e\" /><meta name=\"apple-itunes-app\" content=\"app-id=329541503\" /><meta name=\"page_path\" content=\"seek/cache_details.aspx\" />\n    <meta name=\"page_name\" content=\"PMO Cache Upsell\" />\n<link href=\"https://fonts.googleapis.com/css?family=Noto+Sans:400,700&amp;subset=latin,latin-ext\" rel=\"stylesheet\" type=\"text/css\" /><link href=\"/content/coreResponsiveCSS?v=iaynC8s9yhyBIcftrbWRFH7OdHZU6PRw-_EP1tfbMrw1\" rel=\"stylesheet\"/>\r\n<script src=\"/bundle/modernizer?v=HfmUMlIbhuybNYbtsV4gvygQU2XxNXFZuOsLOTe8PBo1\"></script>\r\n\n        \n        <script type=\"text/javascript\" src=\"/play/dataparameters/datalayer\"></script>\n\n        \n        \n            <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;\n            h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};\n            (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;})(window,document.documentElement,'async-hide','dataLayer',4000,\n            {'GTM-PZRX5BC':true});</script>\n        \n\n        <script type=\"text/javascript\">\n\n            var googletag = googletag || {};\n            googletag.cmd = googletag.cmd || [];\n\n            (function () {\n                var gads = document.createElement('script');\n                gads.async = true;\n                gads.type = 'text/javascript';\n                var useSSL = 'https:' == document.location.protocol;\n                gads.src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js';\n                var node = document.getElementsByTagName('script')[0];\n                node.parentNode.insertBefore(gads, node);\n            })();\n\n            (function (i, s, o, g, r, a, m) {\n                i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {\n                    (i[r].q = i[r].q || []).push(arguments)\n                }, i[r].l = 1 * new Date(); a = s.createElement(o),\n                    m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)\n            })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');\n\n            \n                ga('create', 'UA-2020240-1', 'auto', {userId: 7766546});\n            \n            ga('require', 'GTM-PZRX5BC');\n            \n\n            ga('require', 'linkid');\n        </script>\n        \n        <!-- Google Tag Manager -->\n        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':\n        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],\n        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=\n        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);\n        })(window,document,'script','dataLayer','GTM-N3KS8V2');</script>\n        <!-- End Google Tag Manager -->\n            \n    \n\n    <script type=\"text/javascript\">\n        ga('send', 'pageview');\n    </script>\n\n    <script type=\"text/javascript\" src=\"/play/serverparameters/params\"></script>\n\n    \n    <style>        \n        .heading-3 {\n            margin-bottom: 0;\n        }\n        /* Cache Details | type, GC code, placed by */\n        .ul__cache-details {\n            margin: 1rem auto;\n        }\n        .li__cache-icon {\n\n            float: left;\n            margin-right: 1em;           \n        }\n        .li__cache-icon svg {\n            height: 48px;\n            width: 48px;\n        }\n        .li__cache-type,.li__gccode {\n            display: inline-block;\n        }\n        .li__cache-type::after {\n            content:'|';\n            display: inline-block;\n            padding: 0 .25em;\n        }\n\n        /* Hide Details | difficulty, terrain, size, favorite points */\n        .ul__hide-details {\n            font-size: .875rem; /* 14px */\n        }\n        .ul__hide-details li {\n            display: inline-block;\n            overflow: hidden;\n            width: 46.5%;\n        }\n        .ul__hide-details li:nth-child(odd) {\n            margin-right: 5%;\n        }\n        .ul__hide-details span:first-child::after {\n            content:':';\n        }\n\n        .ul__hide-details span {  \n            display: inline-block;          \n            vertical-align: middle;\n        }\n        .ul__hide-details .span__title {     \n            color: #9b9b9b;                 \n            margin-right: .25em;\n            max-width: 80%;\n            overflow: hidden;\n            text-overflow: ellipsis;\n            white-space: nowrap;\n        }\n\n        .btn-pmo {\n            margin-top: 0;\n        }\n\n        @media screen and (min-width: 600px) {        \n            /* Cache Details | type, GC code, placed by */\n            .ul__hide-details .span__title {\n                max-width: 150px;\n            }\n            .ul__hide-details li {\n                width: auto;\n            }\n            .ul__hide-details li:nth-child(odd) {\n                margin-right: 0;\n            }\n\n            /* Hide Details | difficulty, terrain, size, favorite points */\n            .flexbox .ul__hide-details {\n                display: -ms-flexbox;\n                display: -webkit-flex;\n                display: flex;\n                -webkit-flex-wrap: wrap;\n                -ms-flex-wrap: wrap;\n                flex-wrap: wrap;\n            }\n            .flexbox .ul__hide-details li {\n                -webkit-align-items: center;\n                -ms-flex-align: center;\n                align-items: center;\n                display: -ms-flexbox;\n                display: -webkit-flex;\n                display: flex;\n                position: relative;\n                width: auto;\n            }\n            .ul__hide-details li {\n                line-height: 1.86em; /* 26px */\n            }\n            .ul__hide-details li + li {\n                border-left: 1px solid #9B9B9B;\n                margin-left: 1em;\n                padding-left: 1em;\n            }\n            .ul__hide-details .span_title {\n                margin-right: .25em;\n                width: auto;\n            }\n        }\n\n        @media screen and (min-width: 1140px) {\n            .flexbox .div__cache-info {\n                display: -ms-flexbox;\n                display: -webkit-flex;\n                display: flex;\n            }\n            .ul__cache-details {\n                -webkit-flex: 1 1 auto;\n                -ms-flex: 1 1 auto;\n                flex: 1 1 auto;\n                margin-right: 4em;\n            }\n            .flexbox .ul__hide-details {\n                -webkit-align-items: flex-start;\n                -ms-flex-align: start;\n                align-items: flex-start;\n                display: -ms-flexbox;\n                display: -webkit-flex;\n                display: flex;\n                -webkit-flex: 1 1 auto;\n                -ms-flex: 1 1 auto;\n                flex: 1 1 auto;\n                -webkit-justify-content: flex-end; /* Safari */\n                -ms-flex-pack: center;\n                justify-content: flex-end;\n                margin-top: .9rem;\n            }\n            \n        }\n\n        .premium-upgrade-widget {\n            max-width: 450px;\n            border: 1px solid #e4e4e4;\n            border-radius: 3px;\n            margin: 25px auto 44px;\n        }\n\n        .premium-upgrade-widget header {\n            display: block;\n            border-bottom: 1px solid #e4e4e4;\n            padding: 24px 16px;\n            background: #f5f5f5;\n            text-align: center;\n            min-width: 0;\n            margin-bottom: 0;\n        }\n\n        .premium-upgrade-widget h2 {\n            margin: 0;\n        }\n\n        .premium-upgrade-widget .smaller-title-option {\n            font-size: 16px;\n            font-weight: 400;\n        }\n\n        .premium-upgrade-widget .main-content {\n            text-align: center;\n            padding: 24px 16px 48px;\n        }\n\n        .premium-upgrade-widget .illustration {\n            display: block;\n            margin: 0 auto 24px;\n            height: 90px;\n            width: auto;\n        }\n\n        .premium-upgrade-widget .premium-features-list {\n            padding: 0;\n            margin: 0 0 24px;\n        }\n\n        .premium-upgrade-widget .premium-features-list li{\n            display: block; \n            margin-bottom: 16px;\n            font-size: 16px;\n        }\n\n        .premium-upgrade-widget .premium-features-list li:last-child{\n            margin-bottom: 0; \n        }\n\n        .premium-upgrade-widget .btn-primary {\n            display: inline-block;\n        }\n\n        /* Tablet Styles - 600 */\n        @media only screen and (min-width: 600px) {\n            .premium-upgrade-widget header {\n                padding: 24px 32px;\n            }\n\n            .premium-upgrade-widget .main-content {\n                text-align: center;\n                padding: 24px 32px 48px;\n            }\n        }\n\n\n        /* Desktop Styles - 1024 */\n        @media only screen and (min-width: 1024px) {\n            .premium-upgrade-widget .smaller-title-option{\n                font-size: 14px;\n            }\n\n            .premium-upgrade-widget .premium-features-list li{\n                font-size: 14px;\n            }\n        }\n    </style>\n<meta name=\"og:type\" content=\"article\" property=\"og:type\" /><meta name=\"fb:app_id\" content=\"251051881589204\" property=\"fb:app_id\" /><meta name=\"og:description\" content=\"Solve&#32;the&#32;mystery&#32;and&#32;then&#32;use&#32;a&#32;GPS-enabled&#32;device&#32;to&#32;navigate&#32;to&#32;the&#32;solution&#32;coordinates.&#32;Look&#32;for&#32;a&#32;small&#32;hidden&#32;container.&#32;When&#32;you&#32;find&#32;it,&#32;write&#32;your&#32;name&#32;and&#32;date&#32;in&#32;the&#32;logbook.&#32;If&#32;you&#32;take&#32;something&#32;from&#32;the&#32;container,&#32;leave&#32;something&#32;in&#32;exchange.&#32;The&#32;terrain&#32;is&#32;1&#32;and&#32;difficulty&#32;is&#32;3&#32;(out&#32;of&#32;5).\" property=\"og:description\" /><meta name=\"og:image\" content=\"https://www.geocaching.com/images/facebook/wpttypes/8.png\" property=\"og:image\" /><meta name=\"og:title\" content=\"Kam&#32;a\u017e&#32;sah\u00e1&#32;Plze\u0148?\" property=\"og:title\" /></head>\n\n<body >\n    <script src=\"/bundle/vendor?v=WiI8q8veO30Dlvfez-HjE8Nl0mzPV46bW-lEVyRlu5g1\"></script>\r\n\n    <form method=\"post\" action=\"../seek/cache_pmo.aspx?wp=GC93HA6&amp;title=kam-az-saha-plze\" id=\"aspnetForm\">\r\n<div class=\"aspNetHidden\">\r\n<input type=\"hidden\" name=\"__EVENTTARGET\" id=\"__EVENTTARGET\" value=\"\" />\r\n<input type=\"hidden\" name=\"__EVENTARGUMENT\" id=\"__EVENTARGUMENT\" value=\"\" />\r\n<input type=\"hidden\" name=\"__VIEWSTATE\" id=\"__VIEWSTATE\" value=\"tVCLCNDS2I9oyJqgQbRFHG0q4oX+1HsRC3mEkcpmRomrafC0u+gCbNuWNDxXnxq6zNp4PpUDMBkNbdYfMH9TJoZRcU1tawKcFarQjZVMvPxwX2Nez8ikVao5hByG3uXEsSHn3fVDJbbGQwIf13af1I5hXez+wdJMgc/7qPMtSnjmmg133A8PQ1pOaB4SGCZzJcnDelYfzqCs0Erfe6zJYN1sf484NnSGHe9mXxGlsuj0il8+L8C40Zx0EPpQq2mIVEiw9zAi6fCpIPJO9yGzWI3uF/EZ7gWA2ilF4Naz+XCuqfhZw8v/zIL8oCR8+okwcW+k9ZGuGMsCb+/fZM2aHUhqwOZKDuug2U6KQw0Lv96tl47v7L3BPhlZu7xycQP9C82FxNXkh6EpzFw1/VGvh6aEVmAe6OaCPqyOEagjeuMIJHa2Uq0q/9DROBvpMosquH/XaIyfrvzatTKqPeBUwTc8bOFAdF4AB/d+qrfWVGldsufJp5xpZgdD1T66DRlWW6zCmUk5ZKf+3ZR9o2lp2W9ivMdB9M0uuCPnc+E5/lY3seZAqlFmf9U1RjDEBXJW421/bhxB2jlGwCQ53iy1+AxZ8hRpMYhXc+/oPLLqJRYz+2nUNqjfA2DJcHZVFJ6cgZTVEKVe5x7AzMy+LW1o2OZ+K9bSme520tIcY3ISIb7wyVs6VqcjtbFtVKeEaW9KaDHyY8eMU/xwE821HTnDlPoF5HvD1/Z8ZoDiNZB26+2rCgcc71aWYyzhcf6F+VQCl1CSa0q5mHpecVdaMqeswoqEg60X+/Q2wcYOJn9zeTwlNQ0V6U+12bDf8xLFX/Dh1sY0ifxN9rjbLsIpBIoEYoQTYkibRo1irZ8cgd7J/OwDsXqh4CSLkXAQAcYuP4cPMjzsTROR54kRXs/z5dDurlepp4WaI+07lWEXt3FURKbvOt82Hsofe5KdXMFSMVZZfayTA/skZ+n4EJEClZ8boAIqpjpBsyh3JF6UUEjBgtw4HFS4RIY0x1uJjZznyjsE5d7ScocZcqmuPf20Oki7dzlsr19za0OCqb77YYyU7Od1p+51bJR1jzUeXvszzScV96+1VL0CdT3KCnRxSD4YC96qQYUsyl/B66+NelFqYn1uUMGfcbKnXDhgNSnsa5L7MIr4llyOm3RKYOkRfk5g1kfYgXkeZI4Bv65z9SzaNTcUg66NDfq1fexU9QNjXX2hdJ42+i3y4acr8VCvXVSYehzMxomPdzRau/VWlD1sB2Bxi9ee5psyyHVWq9FQJ/5Z3iBRLimqrwrqLshGRoVMnFqEC668sxC1Lm2MKpcQAFmuVmjQa07Tn2LWpxvMp+OyS8hev2NyKyqxBHvJgg5hQKi2ScCvcbt76JguGV8AdA+IGwlHMh6cN3wBfMs3tCMq6mtXW/J5t0IyA2XA1MFb5abDcSdBuYhj4gSWOoEKXU8TC33Khj0RihoIkfFM2UMyXvS31cqsADE3rZnZT/V/blBoBHAl9LBwRvsFzeulgJyRxCuItmLyToxpLxp+3opDCqpQ3wrliyGlXHNv1lCauX7pglaGN1d1N2eW/q0XVi7KiB0V9V+7qrUtvK5VujpiqU/6Gwz73hfE02uGMYEprl2xHj/C0/gdF5AMKYeRhnTxhEFNG970umG4Ynqdn9pVdPcZ3DZmpdAz79TVsUU0xPpQjR71DvikzTBQU57n0TzTkbFCNcQJkl8jMrWRb4PRfy/avlmME2/gWAmm4QH2XyZNMbRz8hGAooBynZ6cveKXVDatkpGB3QCQZLIRQK0n8LswlxQXZUZ8Vw84tPrI3FUoNquLIZ6o4Tx3vwEAmufwc9vcykDuCq3fvrxr5dHu9fKCZWV381Y/g1DFevbMMU3HUZF55jKiAVrAhoBSC0K50MbAkhel212kX0itEE/q4W6t9Wp3PhWTXjfcJZXgVc4KcrnotvAY81haRTKzEwTFM72YyoYXkmRhkTa/ZQOlQEdM3UXO0ySUZ0wTffKyCZIezBTOQ0UIb1eJw+g2hl3gwWdgMZzImlMGDiD6GnQjd9HxN8h4EGQO5eHkz7snkMDLsUjifU/7w0aSOGVK1mNshnEFjkqgG7Ia6MpjpiVytptmRI1RJn1Pm0LKTt2TSgLzlm3rvVvBg6uQMqcuSw0X/ei2nei3eSNogW3HmajW9qpS4pE3W8VwCF1JcEv0mhrAxALmaUiPuz2EJjXI92iLmGzBUHq4thodNXqg+aVyl+Lx4HeqQE8ftFO3E2aOESc2882AEiarrmZRnPaAxFgHSUJcDHrKDYt24dZNHSoBMlNQ0ZoSRtBvcQX7WSdtDFjCeL22ml0RL7E0OcUvIQmcXGqX7NAuajxJxf7uopcaZiKcC9rxeCtcUxJoEqzg+fuLeZ2UpAKHRpfX1S7vR0cBz1njp+Ip/hyWLuZK0mCX12DPVMpTS9X4aXja7vT2t1yn3ZQm6Z0XP3DzTuKN0eD4Y/zJyNaw7VIKltff+ZPsXDV7+WSovPWX5hY84FuZ8LGqLf7pVxPaPOYxsq60oKmXNh+5ajUd/wWwIzmfMH5lv6El18qckEFtaIsU8wO2Rq3o55B50qOPAT/d8PAboc/iA4G8Pw0quMdheOuaJvoQx+zRlYmwSMlUKRMlQ7tyYdu6PITSGFlA77FBmfPkPgOBsQsU8U71vvH+36zTHH6N6H0hgPN8YHHJXX5Odh6jo1CMkyN4WWTlqOU2MtdfIJBSVuWd8FEA8lsgd0bxZ34HRPkyMhf2SVrxLtIgpDsD+fOp2HBAio224YdCPWErkbr923gFD/jXk6GR16y3VlgMVpztCg/v/+XdTpB39XOFlIjXfclfIZPdULcVBWwBId5j2QtlbZSN2n7SY/0t3EKEqur0HPprjGPCJN6MgufWLkFifWpiHarURZvzbc0FAAcWyv0+Jbkdj+FzyPdE/l6pFQVRHElBkKhvY3uXusRqtUPsXQ/5PM/zzN54OfRJXn0eqDXwaGTjcR6UMe583OukdTg1RotUMWWsGQootvvVi/7+SF0Fmhnai6erRH0X0UKzWlQbdIyIhLFtgrUIUIMwMEqFueUX/xikYGQXDF27xhM64A54+5/l7+LvViJyoDwI0Jo0rOWSculTHZT1sQM7GCv3qnqiykxOfpWteS+tWfTZ0+Oty6NIQiD2bhMPQevN3Hxd4LxWcyJzpnGMgaCoRUGKO0pDcVPjUUIo/eIgZ0nz70zl0BcFi4Hb00yZrJGg9VOpsyOFSH1ol03vS94KPM3WYGe6WJJhXsUCnrh57dHQ30RmKi/OfvNDinIAol5BearVTz8vAvifGQmC5GmqtakpATl4vRWq9nX3uAzCDrLNZy/ti8KV+1wzTJzZIB3wB+ATLoZoNRg/m3brRGfZ2iNWsqewbg5Bis0nQujJlqQfF+yMD/zjO2MFxxOdD3IJmvzhce0bAZCniSY4OO254Pt74oftv8d4O3xbuiax4UP/XL0W+r6EU1Hr1al0Sk/G9xAj0P3RTJyrghyPtXg2TOEvjHmFhzWL/lvIr8de1w29UQ4eu6GnW2KTtja9lTZJvzWNKfSmvLJG4nuRGbhRx0TyA74fWHdc04jOW1DfXxsMxnaWK1vuTYv3gc6i4pf6MyJqu/170pB8QEgdhmhzGeyVo+P+ekXzgi9ArMXl6zT1EyX9OHW4C7m0QR7n0hTd7rp6HqI1bopGOs63J/6usBvHjFTPcUY7tRQxEbAQT5boDW1EWgH5tGq3Mn4ZwOmka6FT7ksPfw7lx38QxtiSlkBlOw==\" />\r\n</div>\r\n\r\n<script type=\"text/javascript\">\r\n//<![CDATA[\r\nvar theForm = document.forms['aspnetForm'];\r\nif (!theForm) {\r\n    theForm = document.aspnetForm;\r\n}\r\nfunction __doPostBack(eventTarget, eventArgument) {\r\n    if (!theForm.onsubmit || (theForm.onsubmit() != false)) {\r\n        theForm.__EVENTTARGET.value = eventTarget;\r\n        theForm.__EVENTARGUMENT.value = eventArgument;\r\n        theForm.submit();\r\n    }\r\n}\r\n//]]>\r\n</script>\r\n\r\n\r\n<script src=\"/WebResource.axd?d=pynGkmcFUV13He1Qd6_TZETFLbdR8wwRMdub1eDU5ILCHE7OhotblLUuaNwx3HQ7rYen0g2&amp;t=637453780939909757\" type=\"text/javascript\"></script>\r\n\r\n\r\n<script type=\"text/javascript\">\r\n//<![CDATA[\r\nwindow['headerSettings'] = {\r\n  \"isAuthenticated\": true,\r\n  \"paymentUrl\": \"https://payments.geocaching.com\",\r\n  \"planUrl\": \"\",\r\n  \"gameplayUrl\": \"\",\r\n  \"mainElementId\": \"Content\",\r\n  \"mapUrl\": \"\",\r\n  \"locale\": \"en-US\",\r\n  \"inlinePostfix\": \"--inline\",\r\n  \"publicUrl\": \"https://www.geocaching.com\",\r\n  \"hostname\": \"https://www.geocaching.com\",\r\n  \"username\": \"<USERNAME>\",\r\n  \"findCount\": 0,\r\n  \"avatarUrl\": \"https://www.geocaching.com/images/default_avatar.png\",\r\n  \"isBasic\": true,\r\n  \"showRenew\": true,\r\n  \"showDoNotSell\": true,\r\n  \"userPublicGuid\": \"ea1eccb8-d6a0-42ca-a674-3a1faf7fee6f\"\r\n}; window['userRef'] = 'PR8VFGN';//]]>\r\n</script>\r\n\r\n<script src=\"/ScriptResource.axd?d=uHIkleVeDJf4xS50Krz-yEJRbXY2x1dOBEdM7W-QkNpgaumdwaefPzMErSeG_W29-lHX6vl5G7uDafHaYWCx8Z9aLlo8tZwVtV42ISp6LhT6LbxuVUWMo5GyApWAyPOqkSkf1vCyntgT-PmPv-C6FWxsbWo1&amp;t=2fe674eb\" type=\"text/javascript\"></script>\r\n<script src=\"/ScriptResource.axd?d=Jw6tUGWnA15YEa3ai3FadDbNvwkajNGIHz7aGm4w_MLRMuZ5hwlk3bfOsTs3E4cZZ4ktnTFE_MzciTx4exD15JXabrPKGazf6xj6fW1A8vXJoc3OCqf4cg_BDlVl8fQEsQiziDh4kHnJRWZEQotwuLoezlg1&amp;t=2fe674eb\" type=\"text/javascript\"></script>\r\n<div class=\"aspNetHidden\">\r\n\r\n\t<input type=\"hidden\" name=\"__VIEWSTATEGENERATOR\" id=\"__VIEWSTATEGENERATOR\" value=\"BA1BDC2C\" />\r\n</div>  \n        <script type=\"text/javascript\">\r\n//<![CDATA[\r\nSys.WebForms.PageRequestManager._initialize('ctl00$uxMainScriptManager', 'aspnetForm', [], [], [], 90, 'ctl00');\r\n//]]>\r\n</script>\r\n\n        \n        <!-- Google Tag Manager (noscript) -->\n        <noscript><iframe src=\"https://www.googletagmanager.com/ns.html?id=GTM-N3KS8V2\"\n        height=\"0\" width=\"0\" style=\"display:none;visibility:hidden\"></iframe></noscript>\n        <!-- End Google Tag Manager (noscript) -->\n        <a id=\"ctl00_hlSkipLinksContent\" class=\"visually-hidden\" href=\"#Content\">Skip to content</a>\n        <div class=\"print-only\">\n            <svg viewBox=\"0 0 196 29\" height=\"29\" width=\"196\" role=\"img\" aria-label=\"Geocaching\">\n                <use xlink:href=\"/images/branding/logo-geocaching.svg#gcLogo\"></use>\n            </svg>\n            <hr />\n        </div>\n        \n            <div id=\"gc-header-root\" style=\"background-color: #02874D; min-height: 80px;\"></div>\n        \n\n        <div class=\"content-slide\">\n            \n\n\n            <main id=\"Content\" class=\"main\">\n                \n                \n\n                <div class=\"wrapper\">\n\n                    \n\n                    <div id=\"ctl00_divContentMain\" class=\"content-body\">\n                        \n    \n    <h1 class=\"heading-3\">Kam a\u017e sah\u00e1 Plze\u0148?</h1>\n\n    <div class=\"div__cache-info\">\n        <ul class=\"ul__cache-details unstyled\">\n            <li class=\"li__cache-icon\">\n                <svg class=\"icon cache-icon\" role=\"presentation\">\n                    <use xlink:href=\"/app/ui-icons/sprites/cache-types.svg#icon-8\" />\n                </svg>\n            </li>\n            <li class=\"li__cache-type\">                \n                Mystery\n            </li>\n            <li class=\"li__gccode\">\n                GC93HA6\n            </li>\n            <li>\n                <span id=\"ctl00_ContentBody_uxCacheBy\">A cache by Denny\u0161\u00e1k_a_Baty</span>\n            </li>\n        </ul>\n         \n        <ul class=\"ul__hide-details\">             \n            <li><span id=\"ctl00_ContentBody_lblDifficulty\" class=\"span__title\">Difficulty</span>\n                <span>3</span>\n            </li>\n        \n            <li><span id=\"ctl00_ContentBody_lblTerrain\" class=\"span__title\">Terrain</span>\n                <span>1</span>\n            </li>\n\n            <li><span id=\"ctl00_ContentBody_lblSize\" class=\"span__title\">Size</span>\n                <span>Small</span>    \n            </li>\n\n            <li><span id=\"ctl00_ContentBody_lblFavoritePoints\" class=\"span__title\">Favorite Points</span>\n                <span>23</span>\n            </li>\n       \n        </ul>\n    </div>\n\n    <section class=\"premium-upgrade-widget\">\n        <header>\n            <h2 class=\"larger-title-option\">\n                Geocaching Premium\n            </h2>\n        </header>\n        <div class=\"main-content\">\n            <img class=\"illustration lock-icon\" src=\"/play/Content/images/padlockHero.svg\" />\n            <ul class=\"premium-features-list\">\n                <li>Access all geocaches</li>\n                <li>Search and sort with advanced filters</li>\n                <li>Create lists and download maps for offline use</li>\n                <li>Send to Garmin, pocket queries, and more!</li>\n            </ul>\n        \n            <a href=\"https://payments.geocaching.com/?upgrade=true\" class=\"btn btn-primary\" data-ga-category=\"Cache details\" data-ga-action=\"Upgrade Button\" data-ga-label=\"Upgrade\">\n                Upgrade\n            </a>\n        </div>\n    </section>\n\n\n                    </div>\n\n                    <article id=\"ctl00_divContentSide\" class=\"sidebar\">\n                        <div id=\"ctl00_uxBanManWidget\" class=\"sidebar-ad\" style=\"width:160px;\">\r\n\t\n                            <div id=\"gBannerAd\" data-width=\"160\" data-height=\"600\" data-unitname=\"/1011121/all_other_pgs_160x600\"></div>\n                            <p>\n                                <a id=\"ctl00_hlAdvertiseWithUs\" href=\"../about/advertising.aspx\">Advertising with Us</a>\n                            </p>\n                        \r\n</div>\n                    </article>\n                </div>\n            </main>\n\n            \n                <div id=\"gc-footer-root\"></div>\n            \n        </div>\n\n        \n\n\n<script \n    src='https://code.jquery.com/jquery-3.5.1.min.js' \n    integrity='sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=' \n    crossorigin='anonymous'></script>\n\n<script>window.jQuery || document.write('<script src=\"/app/dist/jquery.min.js\"><\\/script>')</script>\n\n\n\n<script\n  src=\"https://code.jquery.com/ui/1.12.1/jquery-ui.min.js\"\n  integrity=\"sha256-VazP97ZCwtekAsvgPBSUwPFKdrwD3unUfSGVYrahUqU=\"\n  crossorigin=\"anonymous\"></script>\n  \n              \n            <script src=\"/account/scripts/custom/message-center-header-widget.js\" defer></script>\n            <script src=\"/bundle/layoutResponsiveJS?v=yf-PPTYJYrcbqCdTwdbt_yj8P0LCIiVbhutGLumMByI1\"></script>\r\n\n\n         \n    <script>\n        $('.btn-pmo, .premium-upgrade-widget .btn-primary').on('click', function () {\n            var $self = $(this),\n                hasFired = false;\n\n            var hitCallback = function () {\n                if (!hasFired) {\n                    hasFired = true;\n                    document.location = $self.attr('href');\n                }\n            }\n\n            ga('send', 'event', 'Cache details', 'Upgrade Button', 'Upgrade', { 'hitCallback': hitCallback });\n\n            // just in case google analytics is having issues.\n            window.setTimeout(hitCallback, 3000);\n\n            return false;\n        });\n    </script>\n\n\n    \r\n\r\n<script type=\"text/javascript\">\r\n//<![CDATA[\r\nvar gaToken = 'UA-2020240-1';//]]>\r\n</script>\r\n</form>\n    <form action=\"/account/logout\" method=\"post\" id=\"form-logout\">\n        <input type=\"hidden\" name=\"returnUrl\" />\n    </form>\n\n    <script type=\"text/javascript\">\n        $(function () {\n            $('a[target=\"_blank\"]').attr('rel', 'noopener noreferrer');\n        });\n            $('#gcNavigation a, #gcNavigation button').on('click', function (Event) {\n                const target = Event.currentTarget\n                if (target.dataset.eventAction) {\n                    let tracker\n                    if ('ga' in window) {\n                        tracker = ga.getAll()[0]\n                    }\n                    const eventAction = target.dataset.eventAction\n                    const eventCategory = target.dataset.eventCategory\n                    const eventLabel = target.dataset.eventLabel\n                    if (tracker && eventAction && eventCategory && eventLabel) {\n                        tracker.send({\n                            eventAction: eventAction,\n                            eventCategory: eventCategory,\n                            eventLabel: eventLabel,\n                            hitType: 'event'\n                        })\n                    }\n                }\n            });\n    </script>\n    \n        <script src=\"/bundle/reactChrome?v=v1PyvyfEQpeFmMPwFeFjdVx6G3Jsnn_JKhKW3GLYrxE1\" defer></script>\n        <style>\n            #gc-header {\n                margin-bottom: 0 !important;\n            }\n        </style>\n    \n    <!-- Server: WEB05; Build: release-20211026.3.Release_5747 \r\n -->\n</body>\n</html>\n"
-        },
-        "headers": {
-          "Cache-Control": [
-            "no-cache"
-          ],
-          "Content-Length": [
-            "26600"
-          ],
-          "Content-Type": [
-            "text/html; charset=utf-8"
-          ],
-          "Date": [
-            "Sun, 14 Nov 2021 01:39:05 GMT"
-          ],
-          "Expires": [
-            "-1"
-          ],
-          "Pragma": [
-            "no-cache"
-          ],
-          "Request-Context": [
-            "appId=cid-v1:019d82c2-5dd7-44cb-aa94-01e052f0d40c"
-          ],
-          "Server": [
-            "Microsoft-IIS/8.5"
-          ],
-          "Set-Cookie": [
-            "gspkauth=02g846KZahXENc0Sbzbf6qfcsq27dwweyyU6dN3VFoFvjQmtceQRcsONaVVvdj0056r-Z1QT6TRHH6YeF9RVSeMf0PMVejlJmfYJ_xT67XEPaKYcfBVRwXhYUVtcZR5H0rT7mn6jegorPlztr9S8dfQ3iAzFxkNWC0au--wSZrA1; domain=.geocaching.com; expires=Tue, 14-Dec-2021 01:39:05 GMT; path=/; secure; HttpOnly",
-            "Culture=en-US; path=/; secure; HttpOnly",
-            "gspkauth=<AUTH COOKIE>; domain=.geocaching.com; expires=Tue, 14-Dec-2021 01:39:05 GMT; path=/; secure; HttpOnly"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "X-AspNet-Version": [
-            "4.0.30319"
           ],
           "X-Content-Type-Options": [
             "nosniff"
@@ -328,11 +231,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/geocache/GC93HA6_kam-az-saha-plze"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=false&skip=0&sort=distance&origin=49.73717%2C13.38097"
       }
     },
     {
-      "recorded_at": "2021-11-14T01:39:06",
+      "recorded_at": "2023-01-12T18:36:10",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -349,10 +252,10 @@
             "keep-alive"
           ],
           "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; Culture=en-US; __RequestVerificationToken=<AUTH COOKIE>"
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.26.0"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
@@ -360,7 +263,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjI0sjC1NDPQUcpLzE1VslLyzs9LTc5LVCgrTk3OUCgpSswtS8zKVNBVKMuvyi/LS1TSUUrOTwGpdHc2DImMdAcKFBSl5maW5vrn5VQqWaUl5hSn6iilJZblF2WWpAbkZ+aBrDPXUUpPzU9OTM5IDaksAOq3ABmUV5KYmZdaBBEx0lFKyUxLy0wGOhBokLEe0FUlqUVFQCVAd+qZ6iiVFqcWueWX5gHdDbUGJOKSmeKXX+KWiSQMtie4JLGkFGg10JiC/OKS1BTn/PyilMy8xJJUoGi1Uk5iSWZJKcgvJpZ65sbmBhbGOko5+XnpUFFDYz1jCwOTWqCzUoHuzCkOLcoB+lsf5g99RAhkJBa7p+aX5JcWwZ0AFPLJT3cpSkwrgYsV5CQmp6a4AB0ANMfIwMBS18BM18g4xMDACoyAJuWXA8MD5DpoKAcEmQYG+XkAZUBehUaSo49PprdCSWpirhLQdTmJxSXgUIEbbGSoa2Cia2AYYmgENbhWBxLdZpZG5kaG8Nj2yAeFh0IuUCMQZ2ZXokSvmaF3EJHRawgMOlLjFxSjdIxfS3NDYCJEj19zUwtjvDEMDQQyY9hcFxjJhhb4Y9jIwivcDDWGU1Kz0sxNccauoYGukQl67CpZmZqZGBoAwxFqSEBOVWpecXYqMBvn56RmJZUWo8avYUBQOJHxCzQUNXqB8T3Q0YuWfQ3N0KMXlH0tzczxRi80DMiPXmNdI3P80WvobAAuJJCit6w0pRJ35AJzryV65AKzrpmhsak5MFvBYtdXQdnUQiEgsSCzCBTNKEWzuVdQkCmRcWuJHrfoWRcsghy3JihFsxGt49bYzBI964Li1gQY4/jiFhYGpMYtJCIMLXQNjHSNTPHHrYm5ZSSoeECK26DM5BDXAJyxa2Cha2iELXaNjSwNEPUwKHZNTBV8gaGj8GF+TydK5Hq7hLsSGbkmZqTGLlrFawri0TR2DUzQK15Q7Bqam+KNXGgYkB+5xsCMhj9yXdwDvFxQI7cqJTUjMQtn5ALLZfSsC4pcCwMDM1NLRMHsnZirkHh0n0JxYsbhhQqgYvpohz1yDFsaeziCagSUGC4pKkWPYGBwGqHXvKRGsCFFEYwzgmBeIDWCoGFpAMwlugbouQ8tgowdDQNBMkgR5JKal1d5dOHhhdnxifFOiUDv4owrUHShxxUoSZoYGyLyYZS/v4JnUWYxcuxEOZuCkgWh7Ife7IXVkvgjB1xTotebpEYOCbnPxMgYPfeB6k1DQ/SyFSV2oUFAauRCAh/Y6AUFPnqrCL3aNIkwC0SNXN/M5IzEnGAFNQW3nPxyoHo8cQtq/RpYGRtaGZvB49bQwNDU0AzoXah57pW5mdnIMWvoHm5qQihqYSUretSi5ztwIwk5ao3Qqk30fEftqLVErzYhLV5j9KhFaxJBw4DMuAVWb8BCED3jord4zZwjvVHj1isV6KGiTLxRitzkjdVRKskvScxRsrKoBQQAAP//kRQ2jNcOAAA=",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwsDQyNzHTUcpLzE1VslJyT80PO7y3qixRQVfBO7EoNUchIDEn9UhvaraSjlJyfgpYjbOjkaVLAFCgoCg1N7M01z8vp1LJKi0xpzhVRyktsSy/KLMkNSA/Mw9kkYGOUnpqfnJickZqSGUBUD/QsuT8vJLEzLzUIrhISmZaWmYy0GlAgwz1gHpKUouKgEqgPLD24JLEklKIiQX5xSWpKc75+UUpmXmJJalA0WqlnMSSzJJSkBNNLPXMjS0tjYAG5+TnpUNFDY31jC0sDS0ta4H2pQIdkFMcWpQD9JA+zIH6CK9lJBYDw6Ikv7QI7rOCnMTk1BQXoHVAPUYGRsa6Boa6RhYhhqZWBgZABNSVXw70FMgt0KAKCHJ2dg9zBsqUFqcWQcM4JTMls7RYD2hqcr4S0C05icUlbvmleTCjDQyA5oJRCNhciNElRYnJ2YlJOanOQKUl4FAoSk3PzAcGkVJATlXq0Y7i7MN7FbKLErPAUQVUVAQMTCXnqtTkjMxEoFhiSUlRZlIpOLSg0W9kAo/58IzU1JzkjMTMIoXE5OTU4uJMoF1AXZnFjgUFOZnJIKuVrEqKSlNrdSCaEakmKDU5Pzc3NS8lNUUhLb9IITszpRivVhNDuN7gkqL8nJxUdFvRtabWxsLtBSZZI4QBHvmgNKCQCww8IM7MrkROqYZmht5BRKZUQ2P0pGqBnlStjFCTqrGeKUpSBfLISqrmhuboSdXYwtzUwhhfUoX5jVBSNTIwMNc1sNQ1tEBOT+hJNSDIyMIr3AwtqaZmpZmboidSiKFGRrqGRroGpiGGRrRNpCbAQIe6xy81NaUYGNXACEvNS8xLRk8qqKmMUOpG10xq6kbXSih1o9uKRStCp0t+OrotaEqByRWq1rEMmEJAKhSMTPTN0XWhhgkwiUJ1BSQWZWfmpSvkpSYWJYFyDW5dxogocMpMrkzOAUYPunqUEABGPDwEUhNzSjIUilILSzOLUlPQ9aHag/CTLzBFF6Fbha4FFAwIDyGCITNPoRyURorQtaIVJaZmJoYGSCECTKJ5xdmpCqBYS81KKi1GLUwMA4LCgQLEFCZAQ1HLEqDP6FKWmBuaYSlLDCzNzPGWJVCvEVeWGOsameMvSwydDSLdgTJIZUlZaUolekkCMRJSkhiZDXRJgp5SSM1r6LqA8QDVFJKYnVqsAEzKxQolGYl5Cvl5qQoZoEBG1w4Oc3heRZRBAaVJQDXAdJmYV1yQXwRMEsCgQM+56GkcWpCZGRqbmgOrMphRvgrKphbAdl0BMDsCUzsorOBJ3NwrKMiUyCRuiZ7E0atLsAhyEjdBadkZkZrEgQaCk7iZJXp1CUriJsCEjy+Jw7xGKIkbGRha6BoA06Mp/iRuYm4ZCap+kZJ4UGZyiGsAeiKHGAqtLk1oncgJVVzoiQUlxaFXP+gJi9QsgW4DqXkC3VYrU0RhHZwBzAcKGZnA4lrDxlAhO1cTXSepVRK6Pog/gckc5uLM5Gz0QEHPbWZmxkaWBgi7QLnNxFTBF5isFT7M7+lEyWzeLuGuRGY2E0K5DSKCWqEg5zZT9H4UodwGNBCc2wxMLIBRjZ7bDM1N8WY2qNeIy2zGuoYofR30zBYQ5OIe4OWCmtmqUlIzgPmC3pkNvQMFj2n0JiZ6Yw89M6BnN/SURWp2w6YLvd2G3phCV2+G8E5IUWqqQnJOZm4SqI2InlXQdUNsg2t2hulLB9ZQ6JrRsw48h1qaGBsick6Uv7+CZ1EmyMHwHBPlbApKBcRkGGBBg5pfgEGBnl/Qxx3QG2Bk5RcTI1ArFj2/GBgaotdOKBkG6jNC+QXY/jIDZhb0vhx6fgkyNIkwC0TNL76ZwMSZE6ygpuCWk18OVI8n56C3xaidc0CxTagthp5Q4GmUUP2GrhWpDiDUMUPXipT/0LMqulJSsyq6LlIrRjTthHI6unpC1SG6PkQ2NTQwNDU0Q/jRvTI3E2V00NA93NSEUC6FVWvouRS9VgOXKsi51AitDYleqxGZSy3R25CQIRdj9FyK1k2Ceo2IbGqha2gAGh1Bz6aoQy5mzpHeqNnUKxXo+KJM9NwJMRW9XqN27kSv10C2otdr6HkFkkZQ6jVC+Qw9fRHKZ+hKCeUzfLoIDYCg6yKUvdDVQ92GCD/kUiqxRCEvMz2jBL9e9BENkL/QRzTQc2dtrI5SSX5JYo6SlXktIAAA//+MCXEa6BcAAA==",
           "encoding": "utf-8",
           "string": ""
         },
@@ -375,16 +278,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "1151"
+            "1684"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "83c02b63-a3f2-4539-a27f-a6ddfdc4648f"
+            "67a1cbe6-ba55-4c24-8df9-69b1f9097fbd"
           ],
           "Date": [
-            "Sun, 14 Nov 2021 01:39:05 GMT"
+            "Thu, 12 Jan 2023 18:36:09 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -410,7 +313,7 @@
       }
     },
     {
-      "recorded_at": "2021-11-14T01:39:07",
+      "recorded_at": "2023-01-12T18:36:10",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -427,10 +330,10 @@
             "keep-alive"
           ],
           "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; Culture=en-US; __RequestVerificationToken=<AUTH COOKIE>"
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.26.0"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
@@ -438,7 +341,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjI0sjC1NDPQUcpLzE1VslLyzs9LTc5LVCgrTk3OUCgpSswtS8zKVNBVKMuvyi/LS1TSUUrOTwGpdHc2DImMdAcKFBSl5maW5vrn5VQqWaUl5hSn6iilJZblF2WWpAbkZ+aBrDPXUUpPzU9OTM5IDaksAOq3ABmUV5KYmZdaBBEx0lFKyUxLy0wGOhBokLEe0FUlqUVFQCVAd+qZ6iiVFqcWueWX5gHdDbUGJOKSmeKXX+KWiSQMtie4JLGkFGg10JiC/OKS1BTn/PyilMy8xJJUoGi1Uk5iSWZJKcgvJpZ65sbmBhbGOko5+XnpUFFDYz1jCwOTWqCzUoHuzCkOLcoB+lsf5g99RAhkJBa7p+aX5JcWwZ0AFPLJT3cpSkwrgYsV5CQmp6a4AB0ANMfIwMBS18BM18g4xMDACoyAJuWXA8MD5DpoKAcEmQYG+XkAZUBehUaSo49PprdCSWpirhLQdTmJxSXgUIEbbGSoa2Cia2AYYmgENbhWBxLdZmaGxqbmwLCHmhTgq6BsaqEQkFiQWZSaV5yNEr/mXkFBpkTGryWh+AWLIMevCUr8GtE6fo3NLA2BiRA9fk0MzczxxTAsDEiNYUhEGFroGhjpGpnij2ETc8vIINQYDspMDnENwB27FrqGRthi19jI0gCRmUGxa2Kq4AsMHYUP83s6USLX2yXclcjINTEjNXbRcq8piEfT2DUwQc+9oNg1NDfFG7nQMCA/co11DQ3xR66Le4CXC2rkVqWkZiRm4YxcQwNdA0sskWtpZG5kCI9bj3xQYCjkAjUCcWZ2JUrJbGboDUpRxESuITDcCEUuetEMyqzoRTMNI9fSHD3rgiLX3NTCGD12UQpnaCCQGruQiDAwB8aCrqEF/tg1svAKN0ON3ZTUrDRzU3yxa2SCHrsgf5oYGyJybpS/v4JnUWYxcqRGOZuCEhKhOEWvbWERiJ5fUaMUHIl0jFITI2P0/AqqbQ0N0UtjlCiFBgGZMWoGzKyEYjTI0CTCLBA1Rn0zkzMSc4IV1BTccvLLgepxxi2wZAZWugZWxoZWxmbwuDU0MDQ1NAN6F2qee2VuZjZKdnUPNzUhFLWwshg9atFzKzB7okatEVpFi14UUztqLdErWkhuNUaPWrTcCg0DMuMWWCECi030ihY9t5o5R3qjxq1XKtBDRZl4oxQ9uwKDx9TMxNAAmEdgFW1OFaj1lApsMOfnpGYllRajFseGAUHhRMYv0FDU+AXGJqHSGD3rUjt+0RrKwCYTevwCs64lekMKLX6hYUBm/AJLY2NdI3P0+EXLu84G4OY4UvyWlaZU4o1c9JoWGDYWwKLC1BIRu96JuQqJR/cpFCdmHF6oAIrrox32yPFraezhCKoFUOK3pKgUPXqBoWmEXtui51+ICHpTCjl+0fMvKfGLM3pgXiA1eqBhaQBsj6JnP/ToCTJ2NAwEySBFj0tqXl7l0YWHF2bHJ8Y7JQK9iyeuDA2Q4ipWR6kkvyQxR8nKohYQAAD//34SCunXDgAA",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwsDQyNzHTUcpLzE1VslJyT80PO7y3qixRQVfBO7EoNUchIDEn9UhvaraSjlJyfgpYjbOjkaVLAFCgoCg1N7M01z8vp1LJKi0xpzhVRyktsSy/KLMkNSA/Mw9kkYGOUnpqfnJickZqSGUBUD/QsuT8vJLEzLzUIrhISmZaWmYy0GlAgwz1gHpKUouKgEqgPLD24JLEklKIiQX5xSWpKc75+UUpmXmJJalA0WqlnMSSzJJSkBNNLPXMjS0tjYAG5+TnpUNFDY31jC0sDS0ta4H2pQIdkFMcWpQD9JA+zIH6CK9lJBYDw6Ikv7QI7rOCnMTk1BQXoHVAPUYGRsa6Boa6RhYhhqZWBgZABNSVXw70FMgt0KAKCHJ2dg9zBsqUFqcWQcM4JTMls7RYD2hqcr4S0C05icUlbvmleTCjDQyA5oJRCNhciNElRYnJ2YlJOanOQKUl4FAoSk3PzAcGkVJATlXq0Y7i7MN7FbKLErPAUQVUVAQMTCXnqtTkjMxEoFhiSUlRZlIpOLSg0W9kAo/58IzU1JzkjMTMIoXE5OTU4uJMoF1AXZnFjgUFOZnJIKuVrEqKSlNrdSCaEakmKDU5Pzc3NS8lNUUhLb9IITszpRivVhNDuN7gkqL8nJxUdFvRtabWxsI0GxoYmhqaGSPSbGVuJkryNHQPNzUhMnkCAwA1eVqgJ08roE3IydMIJXmCeeQlT0Nz9ORpbGFubGiOL3nCvEYoeRoZGFjoGhroGpgipyH05BkQZGTmHOmNmjy9UoGOL8pET5kQU42MdA2NdA1MQgyNBjploqURcCgQSl/oetGTJih1wXW65Kejp2I0pYg06FgGjC+QCgUjE31zvLqMTOG6AhKLsjPz0hXyUhOLkirx6jI2gutyykyuTM4BhhW6ehS3IcIPOXcmlijkZaZnlODXi3Ahwl+ZeQrlwCwDTD/oWlFzp5mZobGpOTAXwfzoq6BsagGsRgoyi1LzirNB8Q3PqeZeQUGmROZUS0I5FSyCnFNN0HIq0Fvk5FQzrDnVxNAMb06FeY1QTjUyMLTQNTDSNSKQU03MLSODUHNqUGZyiGsAekaFGEq3jEqoFsCXTdHzGnrCQs9r6GkSPa+h26BkBYw4qK6QxOzUYgVgtilWKMlIzFPIz0tVyADFCrp+ZFtNETkhOCO/qEQhIzM7VUHDxlAhO1cTXSdqDQcMXHgJlJqYU5KhUJRaWArMAyno+lD9CUzmMBdnJmejBwp6bjMzMzayNEDYBcptJqYKvsBkrfBhfk8nSmbzdgl3JZTZYNUiodwGEUHObcYouc0UvV4klNuABoJzm4GJBTCq0XObobkp3swG9Rpxmc1Y1xClaYWe2QKCXNwDvFxQM1tVSmoGMF/QO7Oh14rwmEavFdFrNvTMgJ7d0FMWqdkNXRehSgpdPTj1IrwTUpSaqpCck5mbBKoQ0bMKum6IbXDNzjB96cCKFF0zetaBWw7s+RghgsQjH5QmFXKBcQrEmdmg6hjRojQz9AYVvsRkHVDQEco6wHBCzTrAcgapx4NeURHKOrAmpTl6RQVuUppaGKPnHZQmJdRvhPIOsElprmtgqWtogZ530JqUFl7hZqh5JyU1K83cFD3vQAyF5h1TWucdKxNE4vRLTU0pBkY1qD2Tl5iXjJ5v0BpshDIdumaUJA7XS6h6RNdKqBGLrhUl+6LndHSlpOZ0dF2EGrHougiVD+jqoSFAqBJF1wezB+EnX2CKLkK3Cl0LKBjQ27ygYEBv86IXJXB3WpoYGyLcGuXvr+BZlAmyEF6CRDmbgioUYgoQYB5GLT+AoYZe9aKPmFCl/DAxAgUcevlhYIjeJUUtP6A+I6L4MAPWu4SKjyBDkwizQKAMUvHhmwnMcjnBCmoKbjn55UD16AUJ2HhIQWJkNtAFCXpCQS8LQPoIlQXoWgmVBehaCZUF6EoJlQV4dZHaxkbTjl4ooOdUdPWECgV0fYhsampmYmiAVHABEwCwQ5qqAArQ1Kyk0mLUOt8wICicyCwLNBQ1ywIDklCVT5Usaw7shWLJspbofVO0Kh/qNUJ5FlLlG+samRPIs84Gke6oebasNKUSPZ9CjKR3PgXZip5P0XMMqdkAXRep2QCqHaV1DhqthqXM0iSgGmC6TMwrLgB2O4Fxnp+HXsGipfFYHaWS/JLEHCUr81pAAAAA//+jYN256BcAAA==",
           "encoding": "utf-8",
           "string": ""
         },
@@ -453,16 +356,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "1164"
+            "1672"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "480e87ae-7bf2-4e64-a5dd-91513090de98"
+            "b6a14d9c-812b-42c7-95f5-d1530b037ed9"
           ],
           "Date": [
-            "Sun, 14 Nov 2021 01:39:06 GMT"
+            "Thu, 12 Jan 2023 18:36:09 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -488,7 +391,7 @@
       }
     },
     {
-      "recorded_at": "2021-11-14T01:39:08",
+      "recorded_at": "2023-01-12T18:36:10",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -505,10 +408,10 @@
             "keep-alive"
           ],
           "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; Culture=en-US; __RequestVerificationToken=<AUTH COOKIE>"
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.26.0"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
@@ -516,7 +419,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjKxNDE2NNBRykvMTVWyUory91fwLMosVtJRSs5PAYm4O0c5m7oA+QVFqbmZpbn+eTmVSlZpiTnFqTpKaYll+UWZJakB+Zl5IEPNdZTSU/OTE5MzUkMqC4DajUDm5JUkZualFkFELHSUUjLT0jKTgc4AGmSoZ6qjVJJaVARUAuWVFqcWueWX5gFdB7UGJOKSmeKXX+KWiSQMtie4JLGkFGg10A8F+cUlqSnO+flFKZl5iSWpQNFqpZzEksySUpBXTCz1zI1NjIyNdZRy8vPSoaKGxnrGFgaGhua1QIelAl2aUxxalAP0uD7MJ/rwIMhILHZPzS/JLy2CuwEo5JOf7lKUmFYCFyvISUxOTXEBugBojJGBgZmuoaGuoUWIgYEVGAFNyi8HBgjIedBQDggyNIkwCwTKgPwKjQzfzOSMxJxgBTUFt5z8cqB6oBNzEotLwIEDN94IaLahroFhiKGBlbGhlbEZUBkkbg0NDE0NzYDehZrnXpmbmY0cs4bu4aYmREatCXrUAiMSLWqBNiFHrZEeME7gUQvm0TRqLS0NgekPPWrNjfFHLSwMyIxbC11DA10DU/xxa2TmHOmNGrdeqUAPFWXijVKTEEMjqKnwKDWyMLU0Q+RX7/y81OS8RIWy4tTkDIWSosTcssSsTAVdhbL8qvyyvESU2A6JjHQnFNvoGRl3bAOzNnJsG6PENnpGpnZsmxubG1hgy8gmeOMaGgJkxrWlLjArGxnjj2vTwCA/D9S4dvTxyfRWKElNzMUZ3QYm4ByMHt1mZsZGlgaI6A7wVVA2MVXwBYaPwof5PZ3I0Wvu7RLuSih6YZnZjFD8ohfUaPFrip6bqR2/xgYm2OLX0NwUXwTDwoDUCIbEg6GFroExMOfhj2AX9wAvUGWAFMFVKakZiVk4IxdUQliiRy4wgIE1g6klMJ/A8nJirkLi0X0KxYkZhxcqBORUpR7tsEeOYUtjD0cz9BguKSpFj2BgcBoBw47UCEbLwJREMM4IgnmB1AiChqWBrqERemmLHkFBxo6GgSAZpAhySc3Lqzy68PDC7PjEeKdEoHdxxhUoutDjCpgRLY3MjQzhUeWRD0q4CrlAjUCcmV2JUs6aGXoHoUcTekaExpMhoXgCiqAXtOgtJlLjiVBGRK9WzbFWq6YWxug5EaWohQYCqRENiQgDc2COQW8yoUd0kJGFVzgoMSFFdEpqVpq5Ke7YNdA1Qq9VgaFjamZiaIDIiKCsl1ecnQqsT/NzUrOSSotR49cwICicyPgFGooavcD4HujoRatHDc3QoxdUj1qaobeaUKMXGgbkR6+xrpE5evSitYidDcC1NVL0lpWmoGdd1CYTejELrkMNjU3NgdkKqQ41tVAISCzILAJFM0obydwrKMiUyLi1RI9b9KyLXsRamaC1iGkdt2boLWJw3JoAYxw9blEqUWgYkBq3kIgAVaJGukboZTRa3JqYW0aCigekuA3KTA5xDcAZu6CWthFS7MbqKJXklyTmKFlZ1AICAAD//wtj4V7XDgAA",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwsDQyNzHTUcpLzE1VslJyT80PO7y3qixRQVfBO7EoNUchIDEn9UhvaraSjlJyfgpYjbOjkaVLAFCgoCg1N7M01z8vp1LJKi0xpzhVRyktsSy/KLMkNSA/Mw9kkYGOUnpqfnJickZqSGUBUD/QsuT8vJLEzLzUIrhISmZaWmYy0GlAgwz1gHpKUouKgEqgPLD24JLEklKIiQX5xSWpKc75+UUpmXmJJalA0WqlnMSSzJJSkBNNLPXMjS0tjYAG5+TnpUNFDY31jC0sDS0ta4H2pQIdkFMcWpQD9JA+zIH6CK9lJBYDw6Ikv7QI7rOCnMTk1BQXoHVAPUYGRsa6Boa6RhYhhqZWBgZABNSVXw70FMgt0KAKCHJ2dg9zBsqUFqcWQcM4JTMls7RYD2hqcr4S0C05icUlbvmleTCjDQyA5oJRCNhciNElRYnJ2YlJOanOQKUl4FAoSk3PzAcGkVJATlXq0Y7i7MN7FbKLErPAUQVUVAQMTCXnqtTkjMxEoFhiSUlRZlIpOLSg0W9kAo/58IzU1JzkjMTMIoXE5OTU4uJMoF1AXZnFjgUFOZnJIKuVrEqKSlNrdSCaEakmKDU5Pzc3NS8lNUUhLb9IITszpRivVhNDuN7gkqL8nJxUdFvRtabWxsI1W5oYGwK9DzUgyt9fwbMoE2QhPIFGOZu6EJk+zdHTpxF6+rSyQE+fpijpE8gjJ32aGBkbo6dPYwsDQ0NzfOkT6jNCydPIwMBM19BQ19ACOQ2hJ8+AIEOTCLNA1OTpmwlMBTnBCmoKbjn55UD16EkUkvqNdA2NdI3MQgyNaJtETYDxAXWZX2pqSrFCLjDYS1LzEvOS0RMKqckTXSupyRObVoROl/x0dFvQlAKjH6rWsQwY2yAVCkYm+uZ4dQHTK1RTSGJ2arFCDtBVCiUZiXkK+XmpChmgFIFPuzEiOJ0ykyuTgdrR1aMGBSKjBZekJuaUZCgUpRaWZhalpqDrQ8umhgaGpoZmCD+6V+ZmotQihu7hpiZE5lJgOYWaS4F5Ei2XAm1CzqVGKLUImEdqLoXUIobAEEfPpebG+HMpzGtEZFMLXUMDXQNT/NnUyMw50hs1m3qlAh1flImeOyGmQnKngQmtcyehCgQ9r0BDgVA+Q9eLni7R8xl6EiY1n6HrAvsMWKxDdQUkFmVn5qUr5KUmFiVVousilL3Q1aO6DRF+yKVUYolCXmZ6Rgl+vQgXIvyVmadQDiof0UsB9NxpZmZsZGmAyNwBvgrKJqYKvsAsofBhfk8nckY193YJdyU2o1oSyqno9amVMUpONSU1pwINBOdUAxML9PoUmFMNzU3xZVSY1whlVCMDQwtdA2NglYo/o7q4B3iB6mekjFqVkpoBzFLo+RRsKL3zKchW9HyKntfQ8yl6ZkNP0OiZDT1Romc2dF2Esg26enDqRXgnpCg1VSE5JzM3CZRF0esmdN0Q2+CanWH60oFZG10zetaBWw7sMhkhgsQjH5Qmgc2SklQgzswGFRCIOs7M0DuIyKwDCjpCWQcYTqhZB70pSmrWgVRy5lgrOVMLY/S8g1LJQf1GKO8AKzlzXQNL9LYoet4JMrLwCjdDzTspqVlp5qboeQdiKDTvmNI67xBqgaInFaQqhFCmQ9eMksTRKwb05iu6VqQ2G6FqFV0rerUK0ome09GVEsrp6LoIVavougiVD+jqUUOAUKsVXR/MHoSffIEpugjdKnQtoGBAr4VBwYBeC6MXJTDNpmYmhgZIIQJMonnF2akKoFhLzUoqLUYtTAwDgsKBAsQUJkBDUcsSoM/oUpaYG5qhlyWgbq2lGXqDGbUsgXqNuLLEWNfIHL0sQevXOhtEugNlkMqSstKUSvSSBGIkel+W1iUJyFb0kgQ9W6LnNfREhp7XsOkitasIVIlS7YPGz2ApszQJqAaYLhPzigvyi4BJAhgU6DkXPY1DCzIzQ2NTc2BVBjMK2NI0tQCOKxYAsyMwtYPCCtHU9AoKMiUyiaO3NNGrS4gIchI3QesTkpnEzdD7hOAkbgJM+OhJHKWpCfUaoSQOaWoC0yN6nxAtiZuYW0aCql+kJB6UmRziGoCeyCGGojc1aZbICVVc6CkOvaEJ0Yte/aAnbkJZAt0GUvMEuq2wAhtRWAdnAPOBQkYmsLjWsDFUyM7VRNdJapWErg/iT2Ayh7k4MzkbPVDguS1WR6kkvyQxR8nKvBYQAAD//5neuXToFwAA",
           "encoding": "utf-8",
           "string": ""
         },
@@ -531,16 +434,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "1170"
+            "1695"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "638619d0-a745-4ee4-9704-77eddcbc5a30"
+            "ae819696-2591-4010-9d60-7363eb90e408"
           ],
           "Date": [
-            "Sun, 14 Nov 2021 01:39:06 GMT"
+            "Thu, 12 Jan 2023 18:36:09 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -566,7 +469,7 @@
       }
     },
     {
-      "recorded_at": "2021-11-14T01:39:08",
+      "recorded_at": "2023-01-12T18:36:10",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -583,10 +486,10 @@
             "keep-alive"
           ],
           "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; Culture=en-US; __RequestVerificationToken=<AUTH COOKIE>"
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.26.0"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
@@ -594,7 +497,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjI0MDQ1NDPWUcpLzE1VslJyr8zNzFbSUUrOTwFznQ3dw01NgAIFRam5maW5/nk5lUpWaYk5xak6SmmJZflFmSWpAfmZeSAzTXSU0lPzkxOTM1JDKguA+i1ABuWVJGbmpRZBRIA2pWSmpWUmA10BNMhIz0BHqSS1qAioBMorLU4tcssvzQM6DmoNSMQlM8Uvv8QtE0kYbE9wSWJJKdBqoMaC/OKS1BTn/PyilMy8xJJUoGi1Uk5iSWZJKcgvJpZ65saWlobmOko5+XnpUFFDYz1jC3NjQ/NaoMNSgS7NKQ4tygH6XB/mE31EGGQkFrun5pfklxbBHQEU8slPdylKTCuBixXkJCanprgAnQA0x8jAwELX0EDXwDTEwMAKjIAm5ZcDQwTkPmg4BwQZmTlHegNlQJ6FxoVXKtBDRZlKQKflJBaXgAMFbqqRoa6hoa6BSYihEdTUWh1IlJqamRgamMJjNCCnKjWvODtVoaQoPyc1K6m0uBIlfg0DgsKJjF+goajxC4xNtPg1Qo1fYz2gHnj8GoJ4NI1fc0MzLPFrYGmGP36hYUBm/JrrGhjrGpnjj19DZ4NId9T4LStNqcQbuZbokQv0j5GFqaUZMDSgZnjn56Um5yUqlBWnJmcAozgxtywxK1NBV6Esvyq/LC8RJapDIsFOICaqgaGInpUJRTVKVqZDVBtYAJMfelQbmOCNaGgIkBnRlroGZrpGxvgj2jQwyM8DNaIdfXwyvRVKUhNzcUa3gYmugSF6dIN8amJsiIjtKH9/Bc+izGLkWI1yNnUhN1KBUYgWqcBoRo5UcDTSMVJNjIyxRaohevmMGq3QICAzVs1Aec3QAj1W0bKvSYRZIGqs+mYmZyTmBCuoKbjl5JcD1aPHLXJWBsatgZWxoZWxGTxuzcwMjU3NgQEOK6h9FZRNLRQCEgsyi0AlNkreNfcKCjIlMpot0aMZPe+iR7OVCVo1TOtoNkOvhsHRbAIsvPFFMywMSI1nSEQYWugaGOkaoVfDaPFsYm4ZGYQaz0GZySGuAThjF1S9G6HnXGDsWhqZGxnCI9cjHxQaCrlAjUCcmY1aB5sZeoMsJSZyDYH5g1DsopfM6JmY2rGL3sgyR49dcCPL1MIYPXZRymZoIJAau5CIAFXClui5GD12g4wsvMLNUGM3JTUrzdwUZ+wCW25G6G0sYOhYAIsNU0tEI8s7MVch8eg+heLEjMMLFUBNrqMd9shRbGns4QiyGSWKS4pK0WMYGJ5GhGIYIoJe9yLHMHozmpQYxhlBMC+QGkHQsDQAZhP0VjB6BAUZOxoGgmSQIsglNS+v8ujCwwuz4xPjnRKB3sUZV6DoQo8rUDlrbGRpgKhEQeWsiamCLzAlK3yY39OJUsx6u4S7okcTek6E9XbMKIwnU1LjidScaGxggt5GAuVEQ3NT9IyIUsxCw4DUeIbEA6iYNQZGBf54dnEP8AJV2UjxXJWSmpGYhTtygV0o5PZwrI5SSX5JYo6SlUUtIAAA//+DNTvr1w4AAA==",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwsDQyNzHTUcpLzE1VslJyT80PO7y3qixRQVfBO7EoNUchIDEn9UhvaraSjlJyfgpYjbOjkaVLAFCgoCg1N7M01z8vp1LJKi0xpzhVRyktsSy/KLMkNSA/Mw9kkYGOUnpqfnJickZqSGUBUD/QsuT8vJLEzLzUIrhISmZaWmYy0GlAgwz1gHpKUouKgEqgPLD24JLEklKIiQX5xSWpKc75+UUpmXmJJalA0WqlnMSSzJJSkBNNLPXMjS0tjYAG5+TnpUNFDY31jC0sDS0ta4H2pQIdkFMcWpQD9JA+zIH6CK9lJBYDw6Ikv7QI7rOCnMTk1BQXoHVAPUYGRsa6Boa6RhYhhqZWBgZABNSVXw70FMgt0KAKCHJ2dg9zBsqUFqcWQcM4JTMls7RYD2hqcr4S0C05icUlbvmleTCjDQyA5oJRCNhciNElRYnJ2YlJOanOQKUl4FAoSk3PzAcGkVJATlXq0Y7i7MN7FbKLErPAUQVUVAQMTCXnqtTkjMxEoFhiSUlRZlIpOLSg0W9kAo/58IzU1JzkjMTMIoXE5OTU4uJMoF1AXZnFjgUFOZnJIKuVrEqKSlNrdSCaEakmKDU5Pzc3NS8lNUUhLb9IITszpRivVhNDuN7gkqL8nJxUdFvRtabWxsI0GxoYmhqaGSPSbGVuJkryNHQPNzUhMnkCAwA1eVqgJ08roE3IydMIJXmCeeQlT0Nz9ORpbGFubGiOL3nCvEYoeRoZGFjoGhroGpgipyH05BkQZGTmHOmNmjy9UoGOL8pET5kQU42MdA2NdA1MQgyNBjploqURcCgQSl/oetGTJih1wXW65Kejp2I0pYg06FgGjC+QCgUjE31zvLqMTOG6AhKLsjPz0hXyUhOLkirx6jI2gutyykyuTM4BhhW6ehS3IcIPOXcmlijkZaZnlODXi3Ahwl+ZeQrlwCwDTD/oWlFzp6mZiaEBkheBCSCvODtVARQNqVlJpcUgfyKyqmFAUDiRWRVoKGpWBQY/WlYFBhJyVjXWA+pBqkmAPHKyqrmhGZasamBphj+rQr1GRFY11zUw1jUyx59VDZ0NIt1Rs2pZaUolej6FGAnJp0ZmtM6nViaIdOmXmppSrJALDOuS1LzEvGT0fIaeedATGXrmwaYLGA9QTSGJ2anFCsBsUKxQkpGYp5Cfl6qQAQpkdO0oBQOoSQBLmaVJQDXAdJmYV1yQXwRMEsCgQM+K6Gkc6mlLE2NDYPBBTYry91fwLMoEZUh4wo5yNnUhMl0D/YSaroFBipaugZUSaguJKunaxMgYGAno6drAEL0KQk3XUJ8RkazNdA0NdQ0tCCRrkwizQNRk7ZsJLO1zghXUFNxy8suB6gd7EkdPKKQ2kNC1EqrA0LWiV2BQnegVGLpSQnkQXRepeRBdO6GaDF09NCgQGS24JDUxpyRDoSi1sDSzKDUFXR9aNjUzMzQ2NQfmHViO91VQNrUA9mgKgJqBlRIovuEZ1twrKMiUyBxriZ5j0RuN6DnWygSt0UhmjjVDbzSCc6wJsH7Cl2NhXiOUZY0MDC10DYB5Cr3RiJZlTcwtI4NQs2xQZnKIawB6RoUYit5mpFlGJZTf8FUM6LkGPWGRmmvQbSA126DbamWKaFMFZwCrK4WMTGCrSsPGUCE7VxNdJ6kZCF0fxJ/AZA5zcWZyNnqgoOc2M+BIghEiGD3yQckYWFaWpAJxZjZqs8/M0BuUgojJbKDgJpTb0Nt96PUjqbkN2kUzR89t4C6aqYUxem5DafdB/UYot0HafZboFSR6bgsysvAKN0PNbSmpWWnmpui5DWIoNLeZ0jq3EaoW0ZMKIl0R6tqha0avUwnlcXSt6HUqOB+g16notqLXqeilA7pS9NIBpBa9dEDXhRwmhDqFWHURqkrR1RMqCdD1we1B+MkXmKKL0K1C1wIKBvQ+JCgY0PuQ6EUJPJLNjI0sDRCOBVXcJqYKvsA8q/Bhfk8nOJHC6m1vl3BXoAChogQ82INecaMXJRAR1KIEueI2RR/tIVSUAA0EFyUGJhboTW1gUWJobopekqDU21CvESpJIPW2MbC1jb8kcXEP8AI13ZFKkqqU1AxgpkcvScCGotfb1C5J0Md6QLaiFwjoWROSWtBrbvS8iZ6y0PMmSqJEz5voutBzGXrSR1dvZYbwTkhRaqpCck5mbhIoR6PnNXTdENvgmp1h+tKBJQG6ZvSsUxuro1SSX5KYo2RlXgsIAAD//0wV+MzoFwAA",
           "encoding": "utf-8",
           "string": ""
         },
@@ -609,16 +512,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "1165"
+            "1707"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "0670eaa4-1ad0-462b-b8ff-1bb1ca02df72"
+            "49e2fe3b-4372-40d9-ba24-9ef8aa2b7567"
           ],
           "Date": [
-            "Sun, 14 Nov 2021 01:39:07 GMT"
+            "Thu, 12 Jan 2023 18:36:10 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -644,7 +547,7 @@
       }
     },
     {
-      "recorded_at": "2021-11-14T01:39:09",
+      "recorded_at": "2023-01-12T18:36:11",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -661,10 +564,10 @@
             "keep-alive"
           ],
           "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; Culture=en-US; __RequestVerificationToken=<AUTH COOKIE>"
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.26.0"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
@@ -672,7 +575,81 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjI0sjC1NDPQUcpLzE1VslLyzs9LTc5LVCgrTk3OUCgpSswtS8zKVNBVKMuvyi/LS1TSUUrOTwGpdHc2DImMdAcKFBSl5maW5vrn5VQqWaUl5hSn6iilJZblF2WWpAbkZ+aBrDPXUUpPzU9OTM5IDaksAOq3ABmUV5KYmZdaBBEx0lFKyUxLy0wGOhBokLEe0FUlqUVFQCVAd+qZ6iiVFqcWueWX5gHdDbUGJOKSmeKXX+KWiSQMtie4JLGkFGg10JiC/OKS1BTn/PyilMy8xJJUoGi1Uk5iSWZJKcgvJpZ65sbmBhbGOko5+XnpUFFDYz1jCwOTWqCzUoHuzCkOLcoB+lsf5g99RAhkJBa7p+aX5JcWwZ0AFPLJT3cpSkwrgYsV5CQmp6a4AB0ANMfIwMBS18BM18g4xMDACoyAJuWXA8MD5DpoKAcEmQYG+XkAZUBehUaSo49PprdCSWpirhLQdTmJxSXgUIEbbGSoa2Cia2AYYmgENbhWBxLdZmaGxqbmwLCHmhTgq6BsaqEQkFiQWZSaV5yNEr/mXkFBpkTGryWh+AWLIMevCUr8GtE6fo3NLA2BiRA9fk0MzczxxTAsDEiNYUhEGFroGhjpGpnij2ETc8vIINQYDspMDnENwB27FrqGRthi19jI0gCRmUGxa2Kq4AsMHYUP83s6USLX2yXclcjINTEjNXbRcq8piEfT2DUwQc+9oNg1NDfFG7nQMCA/co11DQ3xR66Le4CXC2rkVqWkZiRm4YxcQwNdA0sskWtpZG5kCI9bj3xQYCjkAjUCcWZ2JUrJbGboDUpRxESuITDcCEUuetEMyqzoRTMNI9fSHD3rgiLX3NTCGD12UQpnaCCQGruQiDAwB8aCrqEF/tg1svAKN0ON3ZTUrDRzU3yxa2SCHrsgf5oYGyJybpS/v4JnUWYxcqRGOZuCEhKhOEWvbWERiJ5fUaMUHIl0jFITI2P0/AqqbQ0N0UtjlCiFBgGZMWoGzKyEYjTI0CTCLBA1Rn0zkzMSc4IV1BTccvLLgepxxi2wZAZWugZWxoZWxmbwuDU0MDQ1NAN6F2qee2VuZjZKdnUPNzUhFLWwshg9atFzKzB7okatEVpFi14UUztqLdErWkhuNUaPWrTcCg0DMuMWWCECi030ihY9t5o5R3qjxq1XKtBDRZl4oxQ9uwKDx9TMxNAAmEdgFW1OFaj1lApsMOfnpGYllRajFseGAUHhRMYv0FDU+AXGJqHSGD3rUjt+0RrKwCYTevwCs64lekMKLX6hYUBm/AJLY2NdI3P0+EXLu84G4OY4UvyWlaZU4o1c9JoWGDYWwKLC1BIRu96JuQqJR/cpFCdmHF6oAIrrox32yPFraezhCKoFUOK3pKgUPXqBoWmEXtui51+ICHpTCjl+0fMvKfGLM3pgXiA1eqBhaQBsj6JnP/ToCTJ2NAwEySBFj0tqXl7l0YWHF2bHJ8Y7JQK9iyeuDA2Q4ipWR6kkvyQxR8nKohYQAAD//34SCunXDgAA",
+          "encoding": "utf-8",
+          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "private"
+          ],
+          "Content-Length": [
+            "54"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "8c1b8f9b-921d-4234-b7f2-9a209dc413a3"
+          ],
+          "Date": [
+            "Thu, 12 Jan 2023 18:36:10 GMT"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ],
+          "x-rate-limit-reset": [
+            "50"
+          ]
+        },
+        "status": {
+          "code": 429,
+          "message": ""
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=founddate"
+      }
+    },
+    {
+      "recorded_at": "2023-01-12T18:37:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=founddate"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwsDQyNzHTUcpLzE1VslJyT80PO7y3qixRQVfBO7EoNUchIDEn9UhvaraSjlJyfgpYjbOjkaVLAFCgoCg1N7M01z8vp1LJKi0xpzhVRyktsSy/KLMkNSA/Mw9kkYGOUnpqfnJickZqSGUBUD/QsuT8vJLEzLzUIrhISmZaWmYy0GlAgwz1gHpKUouKgEqgPLD24JLEklKIiQX5xSWpKc75+UUpmXmJJalA0WqlnMSSzJJSkBNNLPXMjS0tjYAG5+TnpUNFDY31jC0sDS0ta4H2pQIdkFMcWpQD9JA+zIH6CK9lJBYDw6Ikv7QI7rOCnMTk1BQXoHVAPUYGRsa6Boa6RhYhhqZWBgZABNSVXw70FMgt0KAKCHJ2dg9zBsqUFqcWQcM4JTMls7RYD2hqcr4S0C05icUlbvmleTCjDQyA5oJRCNhciNElRYnJ2YlJOanOQKUl4FAoSk3PzAcGkVJATlXq0Y7i7MN7FbKLErPAUQVUVAQMTCXnqtTkjMxEoFhiSUlRZlIpOLSg0W9kAo/58IzU1JzkjMTMIoXE5OTU4uJMoF1AXZnFjgUFOZnJIKuVrEqKSlNrdSCaEakmKDU5Pzc3NS8lNUUhLb9IITszpRivVhNDuN7gkqL8nJxUdFvRtabWxsI0GxoYmhqaGSPSbGVuJkryNHQPNzUhMnkCAwA1eVqgJ08roE3IydMIJXmCeeQlT0Nz9ORpbGFubGiOL3nCvEYoeRoZGFjoGhroGpgipyH05BkQZGTmHOmNmjy9UoGOL8pET5kQU42MdA2NdA1MQgyNBjploqURcCgQSl/oetGTJih1wXW65Kejp2I0pYg06FgGjC+QCgUjE31zvLqMTOG6AhKLsjPz0hXyUhOLkirx6jI2gutyykyuTM4BhhW6ehS3IcIPOXcmlijkZaZnlODXi3Ahwl+ZeQrlwCwDTD/oWlFzp5mZobGpOTAXwfzoq6BsagGsRgoyi1LzirNB8Q3PqeZeQUGmROZUS0I5FSyCnFNN0HIq0Fvk5FQzrDnVxNAMb06FeY1QTjUyMLTQNTDSNSKQU03MLSODUHNqUGZyiGsAekaFGEq3jEqoFsCXTdHzGnrCQs9r6GkSPa+h26BkBYw4qK6QxOzUYgVgtilWKMlIzFPIz0tVyADFCrp+ZFtNETkhOCO/qEQhIzM7VUHDxlAhO1cTXSdqDQcMXHgJlJqYU5KhUJRaWArMAyno+lD9CUzmMBdnJmejBwp6bjMzMzayNEDYBcptJqYKvsBkrfBhfk8nSmbzdgl3JZTZYNUiodwGEUHObcYouc0UvV4klNuABoJzm4GJBTCq0XObobkp3swG9Rpxmc1Y1xClaYWe2QKCXNwDvFxQM1tVSmoGMF/QO7Oh14rwmEavFdFrNvTMgJ7d0FMWqdkNXRehSgpdPTj1IrwTUpSaqpCck5mbBKoQ0bMKum6IbXDNzjB96cCKFF0zetaBWw7s+RghgsQjH5QmFXKBcQrEmdmg6hjRojQz9AYVvsRkHVDQEco6wHBCzTrAcgapx4NeURHKOrAmpTl6RQVuUppaGKPnHZQmJdRvhPIOsElprmtgqWtogZ530JqUFl7hZqh5JyU1K83cFD3vQAyF5h1TWucdKxNE4vRLTU0pBkY1qD2Tl5iXjJ5v0BpshDIdumaUJA7XS6h6RNdKqBGLrhUl+6LndHSlpOZ0dF2EGrHougiVD+jqoSFAqBJF1wezB+EnX2CKLkK3Cl0LKBjQ27ygYEBv86IXJXB3WpoYGyLcGuXvr+BZlAmyEF6CRDmbgioUYgoQYB5GLT+AoYZe9aKPmFCl/DAxAgUcevlhYIjeJUUtP6A+I6L4MAPWu4SKjyBDkwizQKAMUvHhmwnMcjnBCmoKbjn55UD16AUJ2HhIQWJkNtAFCXpCQS8LQPoIlQXoWgmVBehaCZUF6EoJlQV4dZHaxkbTjl4ooOdUdPWECgV0fYhsampmYmiAVHABEwCwQ5qqAArQ1Kyk0mLUOt8wICicyCwLNBQ1ywIDklCVT5Usaw7shWLJspbofVO0Kh/qNUJ5FlLlG+samRPIs84Gke6oebasNKUSPZ9CjKR3PgXZip5P0XMMqdkAXRep2QCqHaV1DhqthqXM0iSgGmC6TMwrLgB2O4Fxnp+HXsGipfFYHaWS/JLEHCUr81pAAAAA//+jYN256BcAAA==",
           "encoding": "utf-8",
           "string": ""
         },
@@ -687,16 +664,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "1164"
+            "1672"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "002b9757-b136-483c-951e-75200819d43c"
+            "fe6f2761-8305-4acb-9c29-2a2879fa52d9"
           ],
           "Date": [
-            "Sun, 14 Nov 2021 01:39:08 GMT"
+            "Thu, 12 Jan 2023 18:37:05 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -722,7 +699,7 @@
       }
     },
     {
-      "recorded_at": "2021-11-14T01:39:09",
+      "recorded_at": "2023-01-12T18:37:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -739,10 +716,10 @@
             "keep-alive"
           ],
           "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; Culture=en-US; __RequestVerificationToken=<AUTH COOKIE>"
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.26.0"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
@@ -750,7 +727,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjIzMzayNDDQUcpLzE1VslIK8FVQNjFV8M0vLlH4ML+nU0lHKTk/BSTj7mzu7RLuChQoKErNzSzN9c/LqVSySkvMKU7VUUpLLMsvyixJDcjPzAMZb2Kmo5Semp+cmJyRGlJZADTAAmRSXkliZl5qEVwkJTMtLTMZ6CKgScZ6QGeUpBYVAZUoWZmCeKXFqUVu+aV5QIdC7QGJuGSm+OWXuGUiCYPtCS5JLCkF2g3UWAB0f2qKc35+UUpmXmJJKlC0WiknsSSzpBTkGRNLPXNjAxMLYx2lnPy8dKioobGesYWhuWkt0F2pQIfmFIcW5QB9rg/ziD4iDDISi91T80vyS4vgbgAK+eSnuxQlppXAxQpyEpNTU1yALgCaY2RgaKFrYKxraBhiYGAFRkCT8suBAQJyHjScA4Jc3AO8XIAyIL9Co6UqJTUjMUsJ6LKcxOIScJDADTUy1DU00DWwDDE0ghpaqwOJXAsDAzNTS1N45Hon5iokHt2nUJyYcXihQkBOVerRDnvkGLY09nA0Q4/hkqJS9AgGBqcRMOwoimBDiiIYZwTBvEBqBEHD0kDX0EjXwBR/BBk7GgaCZJAiyCU1L6/y6MLDC7PjE+OdEoHexRlXoOhCjytgRrQ0MjcyhEeVRz4o4SrkAjUCcWZ2JXI0GZoZegehRxN6RoTGkyGheAKKGKHHEzDJIMUTkEdqPJGUES3NDc3RM6KxhbmphTF6TkSOaFggkBrRkIgwMAfmGF1DC/wRbWThFQ5KTEgRnZKalWZuijt2DXSNTNBjF1TMGhqbmgNDHqmYNbVQCEgsyCxKzSvOTkQpZ72CgkyJjF5LQrGLngutTFByoRGtY9fYzBJb7JoYmpmjxy5KOQsNA1JjFxIRoHLWSNcIPRujxa6JuWUkKAUhxW5QZnKIawDO2DWwABYP6LEL9JGRhamlGaIS9c7PS00G5t6y4tTkDIWSosTcssSsTAVdhbL8qvyyPJTINgyJjHQnMrKB4UgostGzMlqRS+vINjdAr1NBkW1ggh7VKBkZGgKkRjUkVoC52MBM18gYf1SbBgb5eaBGtaOPT6a3QklqYi7u6DbRNTBEj26QT02MDRGxHeXvr+BZlFmMHKtRzqagGpzUSIVFIXoORo1UcDTSMVJNjIyxRaqhIXoORolWaBCQGatm4HoSvXhGi1VDkwizQNRY9c1MzkjMCVZQU3DLyS8HqscVt0DjQXFrYGVsaGVsBo9bUzMTQwNEiwnURgIWz6nATJyfk5qVVFqMWhEbBgSFExnPQENR4xkYpoQyL63jGS3zAstkLPFsiV5So2VfaBiQGdHAethY18icQEQ7G4CLCKSILitNQW9joUYuensYVE4bGJoamgHDHWqGe2VuZjZKfLqHm5oQik9YDwc9PtELY3AMI8enEVrNi97+pXZ8WqLXvJB2lTF6vkWLT2gYkBmfwBoS2BlBr3nR21VmzpHeqPHplQr0UFEm3ihFbljF6iiV5Jck5ihZWdQCAgAA///ezfCL1w4AAA==",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjIzMzayNDDQUcpLzE1VslIK8FVQNjFV8M0vLlH4ML+nU0lHKTk/BSTj7mzu7RLuChQoKErNzSzN9c/LqVSySkvMKU7VUUpLLMsvyixJDcjPzAMZb2Kpo5Semp+cmJyRGlJZADTAAmRSXkliZl5qEVwkJTMtLTMZ6CKgScZ6QGeUpBYVAZUoWZmCeGDtwSWJJaVAI4H8AqCzUlOc8/OLUjLzEktSgaLVSjmJJZklpSA3mljqmRsbmFgY6yjl5OelQ0UNjfWMLQzNTWuB1qUC7c8pDi3KAXpIH+Y+fYTXMhKL3VPzS/JLi+A+K8hJTE5NcQHaBtRjZGBooWtgrGtoGGJgYAVGQF355UA/gZwCDaqAIBf3AC8XoExpcWoRNGSrUlIzErOUgK7ISSwuccsvzUMYamSka2ika2ASYmgEN7SkKDE5OzEpJ9UZqLQE7P2i1PTMfGDYKAXkVKUe7SjOPrxXIbsIaCgoaIGKioChqORclZqckZkIFEssKSnKTCoFBxM0uo1M4DEdnpGampOckZhZpJCYnJxaXJwJtAuoK7PYsaAgJzMZZDU0EGp1ILoN4Zpd8tOL0dValRSVIpQC4wCq1rEMGOYgFQpGJvrmeHUZG8F1OWUmVybnAJ2OT70ZwjshRampCsk5mblJmXnpCkWphaWZRakp6LpRbYNrdobpS09NLCKgORZuuaWRuREiSDzyQWlSIRcYp0CcmV2JnHUMzQy9g4jMOqCgI5R1gOGEmnVMkbKOIYhHTtaxNDc0R886xhbmphbG+PIOzG+E8o6RgYG5roGlrqEF/rxjZOEVboaad1JSs9LMTdHzDsRQaN4xpXXesTJBJE6/1NSUYmBUAyMsNS8xLxk936CmM0KZDl0zahKH6w1KTc7PzU3NS0lNUUjLL1LIzkxBzx2oWk0QiTO4pCg/JycV3VZ0reg5HagTPaejKyWU09F1wcIEmERhVU5iUTYo7+UB814SKNeg6yJUPqCrRwoBRMUWXJKamFOSgZ650fVB7UH4yReYoovQrULXAgoGhIcQwZCZp1AOSiNF6FrRixIzQ2NTc2A2hwUJsBY2tVAISCwAOjWvOBuUIhHVsFdQkClQgJiyBL0WRi9KICLIRYkJSi1sRGpRAjQQXJSYWWIrSkwMzczRixKUahjqNUJFCaQaNtI1MsVflJiYW0aCiiakoiQoMznENQC9KIEYil4NU7soQbS6CGVq1MSCXgmjZ030hIWeNVHSJHrWRLdByQoYcVBdIYnZqcUKwKRfrFCSkZinkJ+XqpABihV0/ci2miJyQnBGflGJQkZmdqqCho2hQnauJrpOUrMruj6IP4HJHObizORs9EBBz20mlibGhgirovz9FTyLMkG64HksytkU1HwjJosBQws1iwHLKPxZDFw/o9fWpGYxc2MTI1AxhZ7FDAwN8WYxqM8I5TBgZW0GbOWiV9boOSzI0CTCLBA1h/lmAiu4nGAFNQW3nPxyoHo8ec3IjNZ5jVC1jZ5Q0GtekD5CmRRdK6GaF10res2Lnr3RlRLK3nh1kZq70bSjV8Ho9SK6ekJ5Gl0fIpuampkYGiA1E4AJAFgVpiqAAjQ1K6m0GLWFbRgQFE5klgUaipplgQFJqIFNlSxrDqz/sGRZS/RaEa2BDfUaoTwLaWAb6xqZE8izzgaR7qh5tqw0pRI9n0KMpHc+BdmKnk/Rcwyp2QBdF6nZAL2SBOk3QhQPAaVJQDXAdJmYV1wArPCAcZ6fh96cRU/jULcbGJoamiE84F6Zm5mNkqzdw01NCCVr2JgLerJGb+yBEzpysjZCa+wBeaQma3C/Eb2xB+k3GqPXRGjJGuo1IpK1ha6hAaiLh56sUfuNZs6R3qjJ2isV6PiiTPSUDTEVvbVH7ZSNPugCshW9/4deH6AnNEJ1CbpeQnUJulL0TARSi56J8Ogi1ItD10WoCkFXD3UbIvyQa+LEEoW8zPSMEvx60btlIH+hd8vQcydMs4UFcIjHBJHRgck07PDeqrJEBV0F78Si1BxgDy0n9UhvKkqWdTSydAkgMssC0xdqlgVahpZlgSKojUfkLAvmkZdlQQUYepa1NLS0xJdlYV4jlGWBmctY18BQ18gixNAUT5Z1dnYPc0bNsimZKZmlxXpAU5Pz0fMtSN7AAGguGCGXBvTOt+h5Dz3hEWo9omtFbTIRyvHoWsFpNlZHqSS/JDFHycq8FhAAAP//W/hY9ugXAAA=",
           "encoding": "utf-8",
           "string": ""
         },
@@ -765,16 +742,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "1165"
+            "1694"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "1d8def44-154b-4469-88c1-8f14fa5fbc17"
+            "8216f992-b92b-4e4f-81b3-5c5a128a8595"
           ],
           "Date": [
-            "Sun, 14 Nov 2021 01:39:08 GMT"
+            "Thu, 12 Jan 2023 18:37:05 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -800,7 +777,7 @@
       }
     },
     {
-      "recorded_at": "2021-11-14T01:39:11",
+      "recorded_at": "2023-01-12T18:37:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -817,10 +794,10 @@
             "keep-alive"
           ],
           "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; Culture=en-US; __RequestVerificationToken=<AUTH COOKIE>"
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.26.0"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
@@ -828,7 +805,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjI0MDQ1NDPWUcpLzE1VslJyr8zNzFbSUUrOTwFznQ3dw01NgAIFRam5maW5/nk5lUpWaYk5xak6SmmJZflFmSWpAfmZeSAzTXSU0lPzkxOTM1JDKguA+i1ABuWVJGbmpRZBRIA2pWSmpWUmA10BNMhIz0BHqSS1qAioBMorLU4tcssvzQM6DmoNSMQlM8Uvv8QtE0kYbE9wSWJJKdBqoMaC/OKS1BTn/PyilMy8xJJUoGi1Uk5iSWZJKcgvJpZ65saWlobmOko5+XnpUFFDYz1jC3NjQ/NaoMNSgS7NKQ4tygH6XB/mE31EGGQkFrun5pfklxbBHQEU8slPdylKTCuBixXkJCanprgAnQA0x8jAwELX0EDXwDTEwMAKjIAm5ZcDQwTkPmg4BwQZmTlHegNlQJ6FxoVXKtBDRZlKQKflJBaXgAMFbqqRoa6hoa6BSYihEdTUWh1IlJpZGpkbGcJj1CMfFBwKuUCNQJyZXYkSu2aG3kFExq4hMO4IRa8RavQa65kiRa8hiEfb6DXHGr2mFsZ4oxcaCGRGr7mugaWuoQWB6LXwCjdDjd6U1Kw0c1PcsWuga4Qeu8DQsTAwMDO1BAYk1BTvxFyFxKP7FIoTMw4vVAjIqUo92mGPHMWWxh6OIJtRorikqBQ9hoHhaUQohiEiqDGMnIEN0TMwSTGMM4JgXiA1gqBhaaBraISe/9AjKMjY0TAQJIMUQS6peXmVRxceXpgdnxjvlAj0LnpcIeVEQwP0uAIGh5GFqaUZ0GewuMrPS00G5sWy4tTkDIWSosTcssSsTAVdhbL8qvyyvESUnBkSGemOHm3oORMab8A0Tyja0DMmWrShZ0xC0UZqxjQ3sACmLfSMaWCCN1tCQ4DUWIfECjBPGpjpGhnjj3XTwCA/D9RYd/TxyfRWKElNzMUZ3QYmugaG6NGtZGVqZmJogMiZoLyYV5ydCozo/JzUrKTSYtSi1zAgKJzICAYaihrBwMAkFMHoJS+NI9jQDL3kBUWwpRl6xYoaxdAwIDOKgSWvsa6ROf4oNnQ2ACcjpCguK01Bz8uotaoleuQCa1UzYyNLA0ReDvBVUDYxVfAFho3Ch/k9nchRa+7tEu5KKGphbSYz9LhFz7zoZS5a5jVFL3OpHbfGBibomRcUt4bmpviiFhYGpEYtJB4MLUBRa2iIP2pd3AO8XFCjtiolNSMxC3fkAhtiWCPX0NjUHBjMSJFraqEQkFiQWQTKwygls7lXUJApkbFrSWrkWpmgtYjRMy61I9cMvUUMjlwTYHbGG7vQMCA/do10jdBrZLTYNTG3jAQ1y5BiNygzOcQ1AGfsglraRuixC/KnibEhIudG+fsreBZlFiPHaZSzKSghEYpS9MoWVvLij1Jw6YteFtMwSk2MjNHzK6gsNkTv5KBGKTQISI1RSOADq1pQGwi9EYxeFJtEmAWixqhvZnJGYk6wgpqCW05+OVA9etzCcy4weoF1roGVsaGVsZlSbayOUkl+SWKOkpVFLSAAAP//X8cz9tcOAAA=",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwsDQyNzHTUcpLzE1VslJyT80PO7y3qixRQVfBO7EoNUchIDEn9UhvaraSjlJyfgpYjbOjkaVLAFCgoCg1N7M01z8vp1LJKi0xpzhVRyktsSy/KLMkNSA/Mw9kkYGOUnpqfnJickZqSGUBUD/QsuT8vJLEzLzUIrhISmZaWmYy0GlAgwz1gHpKUouKgEqgPLD24JLEklKIiQX5xSWpKc75+UUpmXmJJalA0WqlnMSSzJJSkBNNLPXMjS0tjYAG5+TnpUNFDY31jC0sDS0ta4H2pQIdkFMcWpQD9JA+zIH6CK9lJBYDw6Ikv7QI7rOCnMTk1BQXoHVAPUYGRsa6Boa6RhYhhqZWBgZABNSVXw70FMgt0KAKCHJ2dg9zBsqUFqcWQcM4JTMls7RYD2hqcr4S0C05icUlbvmleTCjDQyA5oJRCNhciNElRYnJ2YlJOanOQKUl4FAoSk3PzAcGkVJATlXq0Y7i7MN7FbKLErPAUQVUVAQMTCXnqtTkjMxEoFhiSUlRZlIpOLSg0W9kAo/58IzU1JzkjMTMIoXE5OTU4uJMoF1AXZnFjgUFOZnJIKuVrEqKSlNrdSCaEakmKDU5Pzc3NS8lNUUhLb9IITszpRivVhNDuN7gkqL8nJxUdFvRtabWxsI0GxoYmhqaGSPSbGVuJkryNHQPNzUhMnkCAwA1eVqgJ08roE3IydMIJXmCeeQlT0Nz9ORpbGFubGiOL3nCvEYoeRoZGFjoGhroGpgipyH05BkQZGTmHOmNmjy9UoGOL8pET5kQU42MdA2NdA1MQgyNBjploqURcCgQSl/oetGTJih1wXW65Kejp2I0pYg06FgGjC+QCgUjE31zvLqMTOG6AhKLsjPz0hXyUhOLkirx6jI2gutyykyuTM4BhhW6ehS3IcIPOXcmlijkZaZnlODXi3Ahwl+ZeQrlwCwDTD/oWlFzpxmwQjFCBKJHPigLKOQCExAQZ2aDfInIqGaG3kFEZlRQYBPKqcAwQs6pxnpAjyBVJEAeWTnVHGtONbUwxptToX4jIqea6xpY6hpaEMipFl7hZqg5NSU1K83cFD2jQgyFZlRTWmdUKxNEwvRLTU0pBkY1KJnkJeYlo2c0tHxAKIeja0ave9BTN3rdg66VUNmAbiu6VvSyAV0petmAnofQywZ0XYTKBnRd6GUDSBd62YCuHhICwIiHh0BqYk5JhkJRamFpZlFqCro+VHsQfvIFpugidKvQtVBalJiamRgaIIUIMInmFWenKoBiLTUrqbQYtTAxDAgKBwoQU5gADUUtS4A+o0tZYm5ohqUsMbA0Q6/1UcsSqNeIK0uMdY3M8Zclhs4Gke5AGaSypKw0pRK9JIEYCSlJjMwGuiRBTymk5jV0XcB4gGoKScxOLVYAJuVihZKMxDyF/LxUhQxQIKNrR2ljgHoXsJRZmgRUA0yXiXnFBflFwCQBDAr0nIuexqEFmZmxkaUBIkMG+Coom5gq+ALTksKH+T2dyCnc3Nsl3JVQCoe1ay3Rkzh6dQkWQU3iyA1bU/SGLaEkDjQQnMQNTCyA8YGexA3NTfGlcJjXCKVwIwNDC1AKN0TpG6Gn8IAgF/cALxfUFF6VkpoBTI540jh6s5baaZxQpQdKHuipBSXJodc/6CmL1DyBrgu9JkEv3tHVW5khvBNSlJqqkJyTmZsEqrXQ6xN03RDb4JqdYfrSgXkGXTPurGNobGoOTMRIWcfUAjhgUQDUDKwoQFGAyDteQUGmROYdQlkHIoKcdUzQ+oTotQORWccMvU8IzjomwDoDb96Beo24vAMsytH7hGh5x8TcMhLUckXKO0GZySGuAeh5B2Io3fIOoTYfqTkHPWERyjnoulBtILU6QbPVFNHOCc4AViEKGZnAlo6GjaFCdq4muk701hxcJ3prDl0fij+ByRzm4szkbPRAQc9tJpYmxoYIq6L8/RU8izJBuuB5LMrZFFTmEpPFgKGFmsWABQ96FkMfFURvgJGVxUyMQK1Y9CxmYIg+7IKaxaA+I5TDgO0vM2DVhN6XQ89hQYYmEWaBqDnMNxNYFeQEK6gpuOXklwPV48lr6G0xauc1UGwTaouhJxR4oUwok6JrRUrIhDpm6FqR0jJ69kZXSmr2RtdFau5G006oXkVXTyhPo+urja2N1VEqyS9JzFGyMq8FBAAA///dq6p+6BcAAA==",
           "encoding": "utf-8",
           "string": ""
         },
@@ -843,16 +820,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "1172"
+            "1666"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "3f954469-c3cb-4ca3-9519-9a93ee4fb4bb"
+            "cc0a70cd-5ef2-4cee-8f1a-589efc671f42"
           ],
           "Date": [
-            "Sun, 14 Nov 2021 01:39:10 GMT"
+            "Thu, 12 Jan 2023 18:37:06 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -878,7 +855,7 @@
       }
     },
     {
-      "recorded_at": "2021-11-14T01:39:11",
+      "recorded_at": "2023-01-12T18:37:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -895,10 +872,10 @@
             "keep-alive"
           ],
           "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; Culture=en-US; __RequestVerificationToken=<AUTH COOKIE>"
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.26.0"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
@@ -906,81 +883,7 @@
       },
       "response": {
         "body": {
-          "encoding": "utf-8",
-          "string": "{\"statusCode\":429,\"statusMessage\":\"Too many requests\"}"
-        },
-        "headers": {
-          "Cache-Control": [
-            "private"
-          ],
-          "Content-Length": [
-            "54"
-          ],
-          "Content-Type": [
-            "application/json; charset=utf-8"
-          ],
-          "CorrelationGuid": [
-            "9b97991a-e5f3-49cb-97fa-d7d5d126566a"
-          ],
-          "Date": [
-            "Sun, 14 Nov 2021 01:39:11 GMT"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=31536000; includeSubDomains"
-          ],
-          "Vary": [
-            "Accept-Encoding"
-          ],
-          "X-Content-Type-Options": [
-            "nosniff"
-          ],
-          "X-Frame-Options": [
-            "SAMEORIGIN"
-          ],
-          "X-XSS-Protection": [
-            "1"
-          ],
-          "x-rate-limit-reset": [
-            "49"
-          ]
-        },
-        "status": {
-          "code": 429,
-          "message": ""
-        },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=placedate"
-      }
-    },
-    {
-      "recorded_at": "2021-11-14T01:40:05",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "gzip, deflate"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; Culture=en-US; __RequestVerificationToken=<AUTH COOKIE>"
-          ],
-          "User-Agent": [
-            "python-requests/2.26.0"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=placedate"
-      },
-      "response": {
-        "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjKxNDE2NNBRykvMTVWyUory91fwLMosVtJRSs5PAYm4O0c5m7oA+QVFqbmZpbn+eTmVSlZpiTnFqTpKaYll+UWZJakB+Zl5IEPNdZTSU/OTE5MzUkMqC4DajUDm5JUkZualFkFELHSUUjLT0jKTgc4AGmSoZ6qjVJJaVARUAuWVFqcWueWX5gFdB7UGJOKSmeKXX+KWiSQMtie4JLGkFGg10A8F+cUlqSnO+flFKZl5iSWpQNFqpZzEksySUpBXTCz1zI1NjIyNdZRy8vPSoaKGxnrGFgaGhua1QIelAl2aUxxalAP0uD7MJ/rwIMhILHZPzS/JLy2CuwEo5JOf7lKUmFYCFyvISUxOTXEBugBojJGBgZmuoaGuoUWIgYEVGAFNyi8HBgjIedBQDggyNIkwCwTKgPwKjQzfzOSMxJxgBTUFt5z8cqB6oBNzEotLwIEDN94IaLahroFhiKGBlbGhlbEZUBkkbk3NTAwNgAEKNS4gpyo1rzg7VaGkKD8nNSuptLgSOZoNDQOCwomMZ6ChqPEMDFO0eAbGPHI8G9M5ns0NzYCJET2eDSzN8MYzLAzIjGhzXQNjXSNzAhHtbBDpjhrRZaUplXgj1zLE0AhqJCxyzSyNzI0M4ZHrkQ8KC4VcoEYgzsxGjVozQ+8gIqPWEBiVqHELzLGDK24tzQ2xxK25qYUx3riFBgL5cWuJnonR4zbIyMIr3Aw1blNSs9LMTXHHroGukQl67AJ9ZGBoamgGjAqoKe6VuZnZKFHqHm5qQmSUmhCKUXD+RY5RIz1gVMBjFMyjbYxaYo1RY/RSGS1GoWFAZoxagALfwJRAjJo5R3qjxqhXKtBDRZm4oxSYYbFFqZGFqaUZoqr1zs9LTQZm2bLi1OQMYJmcmFuWmJWpoKtQll+VX5aXiBLbIZHgMoNQbKPXweixjSv/Isc2ev6ldmwDy2YDC/Q6GFQ2m+CNa2gIkBnXlrrAWtjIGH9cmwYG+XmgxrWjj0+mt0JJamIuzug2MAFXvujRbWZmaGxqDgx7WO3rq6BsaqEQkFiQWQSqhlHi19wrKMiUyPi1JBS/6G0sKxO03Ezr+DVDz83g+DUB1sj4YhgWBqTGMCQiDC10DYx0jdBzM1oMm5hbRoLqAKQYDspMDnENwB27wFLCCFvsGhtZGiAyMyh2TUwVfIGho/Bhfk8nSuR6u4S7EopcWFFtRmrsouVeU/Symtqxa2xggp57QbFraG6KN3KhYUB+5BoDy1X8keviHuAFaqUjRW5VSmpGYhbOyAWV/+hNK2DgWACb7KaWiIazd2KuQuLRfQrFiRmHFyqAmtFHO+yRY9jS2MMRVO2jxHBJUSl6BAOD0wi9eUVqBBtSFME4IwjmBVIjCBqWBsBcgl6XokdQkLGjYSBIBimCXFLz8iqPLjy8MDs+Md4pEehdnHEFii6kuIrVUSrJL0nMUbKyqAUEAAD//2ue2CXXDgAA",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjKxNDE2NNBRykvMTVWyUory91fwLMosVtJRSs5PAYm4O0c5m7oA+QVFqbmZpbn+eTmVSlZpiTnFqTpKaYll+UWZJakB+Zl5IEPNdZTSU/OTE5MzUkMqC4DajUDm5JUkZualFkFELHSUUjLT0jKTgc4AGmSoZ6qjVJJaVARUAuWBtQeXJJaUAk0EOq0gv7gkNcU5P78oJTMvsSQVKFqtlJNYkllSCnKhiaWeubGJkbGxjlJOfl46VNTQWM/YwsDQ0LwWaF8q0AE5xaFFOUD/6MMcqA/3WUZisXtqfkl+aRHcYwU5icmpKS5A24BajAwMzHQNDXUNLUIMDKzACKgrvxzoJ5BToAEVEGRoEmEWCJQpLU4tgoanb2ZyRmJOsIKagltOfjlQPdA5OYnFJW75pXkI442MdA2NdI3MQgyN4MaXFCUmZycm5aQ6A5WWgAOiKDU9Mx8YSkoBOVWpRzuKsw/vVcguSswCRxZQUREwPJWcq1KTMzITgWKJJSVFmUml4ACDxTYwPqAu80tNTSlWyAUGe0lqXmJecipQR2axY0FBTmYyyFolq5Ki0tRaHYhGM7i+oNTk/Nzc1LyU1BSFtPwihezMFFBqwa3VxBCuN7ikKD8nJ7VIITE5ObW4OBOkFp9WhE6X/HR0W9CUAqMfqtaxDBjbIBUKRib65nh1AdMrVFNIYnZqsUIO0FUKJRmJeQr5eakKGaAUgU+7MSI4nTKTK5OB2tHVowYFIqMFl6Qm5pRkKBSlFpZmFqWmYNcXC9NpamZiaADMG1DdoASQV5ydqgAK0NSspNLiSuQca2gYEBROZJYFGoqaZYEBiZZlgb5EzrLG1Mmy5oZmwOBHz7IGlmZ4syzMa0TkWXNdA2NdI3MCedbZINIdNc+WlaZUoudTiJH0zqcgW9HzKXqOITUboOsiNRtAtYPDHKbfCFE8BJQmAdUA02ViXnFBfhEwSQCDQiEvNbEoCZRE0d2AnMbNLI3MjRBZ3iMflHaAPi9JBeLMbNQUbmboHURkCgeFCWoSB9ZBdEniluaGWJK4uamFMd4kDvUbcUncEr1aQk/iQUYWXuFmqEk8JTUrzdwUPZFDDIUkcgPTgU7k6EkFkVyNTOAawzNSU3OAVWwmep2Crhm9JgPqJVSToWslVJOha0WvySA60WsydKWEsjC6LliYIFUOiUXZmXnp6JkOXRehCgxdPaEKDF0fij0IP/kCU3QRulXoWkDBgPAQIhgy8xTKQWkEvTxCL0oMDQxNDc0QlrpX5mZmg1MmrPxwDzc1AQoQU34AUxuh4gNoE3LxYaQHDCd48QHmkVV8WGItPozRG7VoxQfUa0QUHxa6hgagnI6/+DBzjvQGyiAVH16pQMcXZaKXHxBToeWHCa3LD0LFAHqGRKuzCGVm9PRFKDOjKyWUmdF1kZqZ0XWhZ2b0HIauHug2RPghF4WJJQp5mekZJeh60XMnur/Qcye6VqSK3szQ2NQcmItgfvRVUDa1UAhILAAWJMBmLSi+4TnV3CsoyJTInGpJKKeidz+tTNByKnpFT2RONcOaU02ALVx8ORXmNUI51cjA0ELXANjwJJBTTcwtI0ENB6ScGpSZHOIagJ5RIYbSLaMSqnLxZVP0vIaesNDzGnqaRM9r6DaQ2vhFt9XKFJETgjOADV6FjExgv0zDxlAhO1cTXSd6ZYoogdArU3R9yP4EJnOYizOTs9EDBT23mZkZG1kaIOwC5TYTUwVfYLJW+DC/pxMls3m7hLsSymywapFQboOIoDarkXObKXq9SCi3AQ0E5zYDEwv0wR5gbjM0N8Wb2aBeIy6zGQPHe/BnNhf3AC/Q4BFSZqtKSc0A5gt6Zzb0WhEe0+i1InrNhp4Z0LMbesoiNbuh6yJUSaGrB6dehHdCilJTFZJzMnOTQBUielZB1w2xDa7ZGaYvHViRomtGzzow7RYWwC6pCaL4AiacsMN7q8oSFXQVvBOLUnOAdVZO6pHeVJS2paORpUsAkZkIGOWoeQhoGVoeAoqgDpgi5yEwj9Q8BGlbgjrt6HnI0tDSEl8mgnmNUCYCpndjXQNDXSOLEENTPJnI2dk9zBk1E6VkpmSWFusBTU3OR89KIHkDA6C5YIScPwc6K6EnPUKVHrpW1IqBUNMUXSs4zcbqKJXklyTmKFmZ1wICAAD//0ekp8voFwAA",
           "encoding": "utf-8",
           "string": ""
         },
@@ -995,16 +898,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "1131"
+            "1659"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "c81e126a-ed48-49be-a793-c8321b56ab9c"
+            "c3f159d8-1156-4c74-a41c-09e28eca0436"
           ],
           "Date": [
-            "Sun, 14 Nov 2021 01:40:05 GMT"
+            "Thu, 12 Jan 2023 18:37:06 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"
@@ -1030,7 +933,7 @@
       }
     },
     {
-      "recorded_at": "2021-11-14T01:40:06",
+      "recorded_at": "2023-01-12T18:37:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1047,10 +950,10 @@
             "keep-alive"
           ],
           "Cookie": [
-            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; Culture=en-US; __RequestVerificationToken=<AUTH COOKIE>"
+            "gspkauth=<AUTH COOKIE>; jwt=<AUTH COOKIE>; __RequestVerificationToken=<AUTH COOKIE>"
           ],
           "User-Agent": [
-            "python-requests/2.26.0"
+            "python-requests/2.28.1"
           ]
         },
         "method": "GET",
@@ -1058,7 +961,7 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrIwMDAztTTVUcpLzE1VslLyTsxVSDy6T6E4MePwQoWAnKrUox32SjpKyfkpIGl3Z0tjD0czoEBBUWpuZmmuf15OpZJVSVFpqo5SWmJZflFmSWpAfmYeyAojYx2l9NT85MTkjNSQygKgfguQQXkliZl5qUVwkZTMtLTMZKCrgAYZ6xnoKJWkFhUBlShZGYJ4pcWpRW75pXlAx6Yl5hQD7QGJuGSm+OWXuGUiCYPtCS5JLCkF2g3UmJIKtCinOLQoB+hwfZhD9BFeyEgsdk/NL8kvLYKbARTyyU93KUpMK4GLFeQkJqemuCSWgALAyMDIQNfQSNfANMTAwAqMgCbllwM9pGRVDQumgCBjR8NAkAzIrdCgdUnNy6s8uvDwwuz4xHinRKB3a3WUchKLS8C+Q5hvqGsIRAYhhkZQ82t1IHFlaGRhamkG9BksrvLzUpPzEhXKilOTMxRKihJzyxKzMhV0Fcryq/LL8hKRo80wJDLSHT3aoB5EjzdzQtEGjFr80QZMT2RHW0F+cUlqinN+flFKZh4wUICi1cBgKsksKQX5xcRSz9zY3MACmLZy8vPSoaKGxnrGFgYmwADFGeuwECA11iGxYmCpa2Cma2SMP9ZNA4P8PFBj3dHHJ9NboSQ1MRdndBuY6BoYoke3kpWZpZG5kSE8tj3yQeGhkAvUCMSZ2ZUo0Wtm6B1EZPQaomdLYuIXGKN0jF9Lc0NgIkSPX3NTC2O8MQwNBDJj2FwXGMmGFvhj2MjCKxxUdiDFcEpqVpq5Kc7YNTTQNTJBj12QP02MDRF5OcrfX8GzKLMYOVKjnE1dCMUpepaFRSkwAtFLWtQoBUciHaPUxMgYW5Y1NDTHF6XQICAzRs3AJSmBGDU0iTALRI1R38zkjMScYAU1Bbec/HKgepxxC8y8wJxrYGVsaGVsBo9bUzMTQwNEnQqqRfOKs1OBRXR+TmpWUmkxat41DAgKJzKegYaixjMwTAllXVrHM1rRbGiGnnVB8Wxphh7PqFkXGgZkRjQw6xrrGpkTiGhnA3AFgBTRZaUp6LUwauRaomdcoH8MDE0NzYDhDjXDvTI3MxslPt3DTU2IjE8T9PhEL4rBMYwcn0YoVS2YR+34RC2KLbEWxcbo+RYtPqFhQGZ8WoBKTfQmFnp8Gpk5R3qjxqdXKtBDRZl4oxS9LAbVtGaGxqbmwKCHZVhfBWVTC4WAxILMIlDORWlJmXsFBZkSGb2WhKIXvVi2MkGLXvTsSu3oNcMavSbATIwvemFhQGr0QiLC0ELXwEjXiED0mphbRoJqc6ToDcpMDnENwBm7oGRjhC12jY0sDRBVLSh2TUwVfIGho/Bhfk8nSuR6u4S7EopcWN41IzV20drJpuiZl9qxa2xggt5OBsWuobkp3siFhgH5kWsMzGj4I9fFPcALVLEjRW5VSmpGYhbOyAUVCMilcayOUkl+SWKOkpVFLSAAAP//1dpMz9cOAAA=",
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsrKwsDQyNzHTUcpLzE1VslJyT80PO7y3qixRQVfBO7EoNUchIDEn9UhvaraSjlJyfgpYjbOjkaVLAFCgoCg1N7M01z8vp1LJKi0xpzhVRyktsSy/KLMkNSA/Mw9kkYGOUnpqfnJickZqSGUBUD/QsuT8vJLEzLzUIrhISmZaWmYy0GlAgwz1gHpKUouKgEqgPLD24JLEklKIiQX5xSWpKc75+UUpmXmJJalA0WqlnMSSzJJSkBNNLPXMjS0tjYAG5+TnpUNFDY31jC0sDS0ta4H2pQIdkFMcWpQD9JA+zIH6CK9lJBYDw6Ikv7QI7rOCnMTk1BQXoHVAPUYGRsa6Boa6RhYhhqZWBgZABNSVXw70FMgt0KAKCHJ2dg9zBsqUFqcWQcM4JTMls7RYD2hqcr4S0C05icUlbvmleTCjDQyA5oJRCNhciNElRYnJ2YlJOanOQKUl4FAoSk3PzAcGkVJATlXq0Y7i7MN7FbKLErPAUQVUVAQMTCXnqtTkjMxEoFhiSUlRZlIpOLSg0W9kAo/58IzU1JzkjMTMIoXE5OTU4uJMoF1AXZnFjgUFOZnJIKuVrEqKSlNrdSCaEakmKDU5Pzc3NS8lNUUhLb9IITszpRivVhNDuN7gkqL8nJxUdFvRtabWxsLtBSZZI4QBHvmgNKCQCww8IM7MrkROqYZmht5BRKZUQ2P0pGqBnlStjFCTqrGeKUpSBfLISqrmhuboSdXYwtzUwhhfUoX5jVBSNTIwMNc1sNQ1tEBOT+hJNSDIyMIr3AwtqaZmpZmboidSiKFGRrqGRroGpiGGRrRNpCbAQIe6xy81NaUYGNXACEvNS8xLRk8qqKmMUOpG10xq6kbXSih1o9uKRStCp0t+OrotaEqByRWq1rEMmEJAKhSMTPTN0XWhhgkwiUJ1BSQWZWfmpSvkpSYWJYFyDW5dxogocMpMrkzOAUYPunqUEABGPDwEUhNzSjIUilILSzOLUlPQ9aHag/CTLzBFF6Fbha4FFAwIDyGCITNPoRyURorQtaIVJSaWJsaGCLdG+fsreBZlgiyElyBRzqYuQD4xBQgwD6OWH8BQQys/gCUKalVHlfLDxAgUcOjlh4GhoTm+8gPqMyKKDzNdQ0NCxUeQoUmEWSBQBqn48M0EZrmcYAU1Bbec/HKgevSCBGw8pCAxMhvoggQ9oaCXBSB9hMoCdK2EygJ0rYTKAnSlhMoCvLqA6RWqKSQxO7VYAZjVihVKMhLzFPLzUhUyQCkCXTuhQgFdPamFAno2heg0NTMxNEAquIAJIK84O1UBFKCpWUmlxah1vmFAUDiRWRZoKGqWBQYkoSqfKlnW3NAMvcoHZVlLM/Qsi1rlQ71GKM9CqnxjXSNzAnnW2SDSHTXPlpWmVKLnU4iR9M6nIFvR8yl6jiE1G6DrIjUbQLWDwxxepSKKh4DSJKAaYLpMzCsuyC8CJglgUKBXsOhpHOp2A0NTQzOEB9wrczNROl2G7uGmJkQma2DDB70li56sgTYhJ2sjlE4XmEdqsoZ0urC2ZI3RayK0ZA31GhHJ2kLX0ADU6ERP1qgtWTPnSG/UZO2VCnR8USZ6yoaYCm3KmtA6ZRNqkaKnbrSERqguQU9fhOoSdKWEMhE+XYTalei6CFUh6OqhbkOEH3JNnFiikJeZnlGCXy96QxHkL/SGInruhGk2MzM0NjUH5iKYH30VlE0tgIMjBcDqC1gXgeIbnlPNvYKCTInMqZaEcip6m9HKBC2noldAROZUM6w51QRYLeHLqTCvEcqpRgaGFroGwNqCQE41MbeMBPVhkXJqUGZyiGsAekaFGEq3jEqoxYcvm6LnNfSEhZ7X0NMkel5Dt4HUGgvdVitTRE4IzgDWUgoZmcDGlIaNoUJ2ria6TvQmHKIEQm/CoetD9icwmcNcnJmcjR4o6LnNzMzYyNIAYRcot5mYKvgCk7XCh/k9nSiZzdsl3JVQZoNVi4RyG0QEtbmHnNtM0etFQrkNaCA4txmYWKD30IC5zdDcFG9mg3qNuMxmDOyk4c9sLu4BXqAeH1Jmq0pJzQDmC3pnNvRaER7T6LUies2GnhnQsxt6yiI1u6HrIlRJoasHp16Ed0KKUlMVknMyc5NAFSJ6VkHXDbENrtkZpi8dWJGia0bPOrWxOkol+SWJOUpW5rWAAAAA//9PL4AZ6BcAAA==",
           "encoding": "utf-8",
           "string": ""
         },
@@ -1073,16 +976,16 @@
             "gzip"
           ],
           "Content-Length": [
-            "1133"
+            "1663"
           ],
           "Content-Type": [
             "application/json; charset=utf-8"
           ],
           "CorrelationGuid": [
-            "776a4d7a-5059-45aa-91ff-8453971c7f06"
+            "63cfb873-8c63-4044-8ba5-a3f501cc5aaa"
           ],
           "Date": [
-            "Sun, 14 Nov 2021 01:40:05 GMT"
+            "Thu, 12 Jan 2023 18:37:06 GMT"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000; includeSubDomains"

--- a/test/cassettes/geocaching_search_rect.json
+++ b/test/cassettes/geocaching_search_rect.json
@@ -25,7 +25,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=datelastvisited"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=datelastvisited"
       }
     },
     {
@@ -103,7 +103,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=distance&origin=49.73717%2C13.38097"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=distance&origin=49.73717%2C13.38097"
       },
       "response": {
         "body": {
@@ -153,7 +153,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=distance&origin=49.73717%2C13.38097"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=distance&origin=49.73717%2C13.38097"
       }
     },
     {
@@ -356,7 +356,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=containersize"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=containersize"
       },
       "response": {
         "body": {
@@ -406,7 +406,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=containersize"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=containersize"
       }
     },
     {
@@ -434,7 +434,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=datelastvisited"
       },
       "response": {
         "body": {
@@ -484,7 +484,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=datelastvisited"
       }
     },
     {
@@ -512,7 +512,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=difficulty"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=difficulty"
       },
       "response": {
         "body": {
@@ -562,7 +562,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=difficulty"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=difficulty"
       }
     },
     {
@@ -590,7 +590,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=favoritepoint"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=favoritepoint"
       },
       "response": {
         "body": {
@@ -640,7 +640,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=favoritepoint"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=favoritepoint"
       }
     },
     {
@@ -668,7 +668,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=founddate"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=founddate"
       },
       "response": {
         "body": {
@@ -718,7 +718,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=founddate"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=founddate"
       }
     },
     {
@@ -746,7 +746,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=founddateoffoundbyuser"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=founddateoffoundbyuser"
       },
       "response": {
         "body": {
@@ -796,7 +796,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=founddateoffoundbyuser"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=founddateoffoundbyuser"
       }
     },
     {
@@ -824,7 +824,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=geocachename"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=geocachename"
       },
       "response": {
         "body": {
@@ -874,7 +874,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=geocachename"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=geocachename"
       }
     },
     {
@@ -902,7 +902,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=placedate"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=placedate"
       },
       "response": {
         "body": {
@@ -948,7 +948,7 @@
           "code": 429,
           "message": ""
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=placedate"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=placedate"
       }
     },
     {
@@ -976,7 +976,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=placedate"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=placedate"
       },
       "response": {
         "body": {
@@ -1026,7 +1026,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=placedate"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=placedate"
       }
     },
     {
@@ -1054,7 +1054,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=terrain"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=terrain"
       },
       "response": {
         "body": {
@@ -1104,7 +1104,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=terrain"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=terrain"
       }
     }
   ],

--- a/test/cassettes/geocaching_search_rect.json
+++ b/test/cassettes/geocaching_search_rect.json
@@ -25,7 +25,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=datelastvisited"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=datelastvisited"
       }
     },
     {
@@ -103,7 +103,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=distance&origin=49.73717%2C13.38097"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=distance&origin=49.73717%2C13.38097"
       },
       "response": {
         "body": {
@@ -153,7 +153,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=distance&origin=49.73717%2C13.38097"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=distance&origin=49.73717%2C13.38097"
       }
     },
     {
@@ -356,7 +356,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=containersize"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=containersize"
       },
       "response": {
         "body": {
@@ -406,7 +406,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=containersize"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=containersize"
       }
     },
     {
@@ -434,7 +434,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=datelastvisited"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=datelastvisited"
       },
       "response": {
         "body": {
@@ -484,7 +484,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=datelastvisited"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=datelastvisited"
       }
     },
     {
@@ -512,7 +512,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=difficulty"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=difficulty"
       },
       "response": {
         "body": {
@@ -562,7 +562,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=difficulty"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=difficulty"
       }
     },
     {
@@ -590,7 +590,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=favoritepoint"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=favoritepoint"
       },
       "response": {
         "body": {
@@ -640,7 +640,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=favoritepoint"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=favoritepoint"
       }
     },
     {
@@ -668,7 +668,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=founddate"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=founddate"
       },
       "response": {
         "body": {
@@ -718,7 +718,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=founddate"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=founddate"
       }
     },
     {
@@ -746,7 +746,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=founddateoffoundbyuser"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=founddateoffoundbyuser"
       },
       "response": {
         "body": {
@@ -796,7 +796,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=founddateoffoundbyuser"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=founddateoffoundbyuser"
       }
     },
     {
@@ -824,7 +824,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=geocachename"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=geocachename"
       },
       "response": {
         "body": {
@@ -874,7 +874,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=geocachename"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=geocachename"
       }
     },
     {
@@ -902,7 +902,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=placedate"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=placedate"
       },
       "response": {
         "body": {
@@ -948,7 +948,7 @@
           "code": 429,
           "message": ""
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=placedate"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=placedate"
       }
     },
     {
@@ -976,7 +976,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=placedate"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=placedate"
       },
       "response": {
         "body": {
@@ -1026,7 +1026,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=placedate"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=placedate"
       }
     },
     {
@@ -1054,7 +1054,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=terrain"
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=terrain"
       },
       "response": {
         "body": {
@@ -1104,7 +1104,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=True&skip=0&sort=terrain"
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.39&take=200&asc=true&skip=0&sort=terrain"
       }
     }
   ],

--- a/test/test_geocaching.py
+++ b/test/test_geocaching.py
@@ -138,7 +138,7 @@ class TestAPIMethods(LoggedInTest):
                         try:
                             distances.append(great_circle(cache.location, origin).meters)
                         except PMOnlyException:
-                            # can happend when getting accurate location
+                            # can happen when getting accurate location
                             continue
                     self.assertEqual(distances, sorted(distances))
 
@@ -154,7 +154,7 @@ class TestAPIMethods(LoggedInTest):
                         try:
                             distances.append(great_circle(cache.location, origin).meters)
                         except PMOnlyException:
-                            # can happend when getting accurate location
+                            # can happen when getting accurate location
                             continue
                     self.assertEqual(distances, sorted(distances, reverse=True))
 

--- a/test/test_geocaching.py
+++ b/test/test_geocaching.py
@@ -111,7 +111,7 @@ class TestAPIMethods(LoggedInTest):
         """Perform search by rect and check found caches."""
         rect = Rectangle(Point(49.73, 13.38), Point(49.74, 13.39))
 
-        expected = {"GC1TYYG", "GC11PRW", "GC7JRR5", "GC161KR", "GC1GW54", "GC7KDWE", "GC93HA6", "GCZC5D"}
+        expected = {"GC161KR", "GCA29DP", "GCZC5D", "GC11PRW", "GC7JRR5", "GC7KDWE", "GC1GW54"}
 
         orig_wait_for = TooManyRequestsError.wait_for
         with self.recorder.use_cassette("geocaching_search_rect") as vcr:
@@ -141,6 +141,22 @@ class TestAPIMethods(LoggedInTest):
                             # can happend when getting accurate location
                             continue
                     self.assertEqual(distances, sorted(distances))
+
+                with self.subTest("sort by distance reverse"):
+                    origin = Point.from_string("N 49° 44.230 E 013° 22.858")
+                    caches = list(self.gc.search_rect(rect, sort_by=SortOrder.distance, reverse=True, origin=origin))
+                    waypoints = {cache.wp for cache in caches}
+                    self.assertSetEqual(waypoints, expected)
+
+                    # Check if caches are reverse sorted by distance to origin
+                    distances = []
+                    for cache in caches:
+                        try:
+                            distances.append(great_circle(cache.location, origin).meters)
+                        except PMOnlyException:
+                            # can happend when getting accurate location
+                            continue
+                    self.assertEqual(distances, sorted(distances, reverse=True))
 
                 with self.subTest("sort by different criteria"):
                     for sort_by in SortOrder:


### PR DESCRIPTION
Since we can pass parameters for reversing and limiting the returned caches directly to the URL requested by `Geocaching.search_rect()`, I believe it would be helpful (at least for me) to have these parameters accessible in Python code.

I also fixed the parsing of the `userFound` property because the returned data format has changed a bit.

And, of course, I reloaded the test cartridges to reflect recent changes.