### PR TITLE
Deprecate the `Geocaching.search_quick()` method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,14 +188,8 @@ Geocode address and search around
     for cache in geocaching.search(point, limit=10):
         print(cache.name)
 
-Find caches with their approximate locations in some area
+Find caches in some area
 ---------------------------------------------------------------------------------------------------
-
-.. warning::
-
-    This is currently not working because of
-    `this issue <https://github.com/tomasbedrich/pycaching/issues/75>`__. Contributions are
-    very welcome!
 
 .. code-block:: python
 
@@ -203,9 +197,10 @@ Find caches with their approximate locations in some area
 
     rect = Rectangle(Point(60.15, 24.95), Point(60.17, 25.00))
 
-    for cache in geocaching.search_quick(rect, strict=True):
-        print(cache.name, cache.location.precision)
+    for cache in geocaching.search_rect(rect):
+        print(cache.name)
 
+If you want to search in a larger area, you could use the ``limit`` parameter as described above.
 
 Load trackable details
 ---------------------------------------------------------------------------------------------------

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -350,38 +350,16 @@ class Geocaching(object):
 
             return bs4.BeautifulSoup(res["HtmlString"].strip(), "html.parser"), None
 
-    def search_quick(self, area, *, strict=False, zoom=None):
-        """Return a generator of caches in some area.
+    def search_quick(self, area):
+        """Search for caches in a specified :class:`.Rectangle` area.
 
-        Area is converted to map tiles, each tile is then loaded and :class:`.Cache` objects are then
-        created from its blocks.
-
-        :param bool strict: Whether to return caches strictly in the `area` and discard others.
-        :param int zoom: Zoom level of tiles. You can also specify it manually, otherwise it is
-            automatically determined for whole :class:`.Area` to fit into one :class:`.Tile`. Higher
-            zoom level is more precise, but requires more tiles to be loaded.
+        :param rect: The :class:`.Rectangle` object representing the search area.
+        :type rect: geo.Rectangle
+        :return: A generator that yields :class:`.Cache` objects.
+        :rtype: Generator[Optional[Cache], None, None]
         """
-        # FIXME
-        warnings.warn(
-            "Quick search is temporary disabled because of Groundspeak breaking change. "
-            "If you would like to use it, please consider helping with this issue: "
-            "https://github.com/tomasbedrich/pycaching/issues/75"
-        )
-        raise NotImplementedError()
 
-        # logging.info("Searching quick in {}".format(area))
-        #
-        # tiles = area.to_tiles(self, zoom)
-        # # TODO process tiles by multiple workers
-        # for tile in tiles:
-        #     for block in tile.blocks:
-        #         cache = Cache.from_block(block)
-        #         if strict and cache.location not in area:
-        #             # if strict mode is on and cache is not in area
-        #             continue
-        #         else:
-        #             # can yield more caches (which are not exactly in desired area)
-        #             yield cache
+        return self.search_rect(area)
 
     # add some shortcuts ------------------------------------------------------
 

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -21,6 +21,7 @@ from pycaching.geo import Point, Rectangle
 from pycaching.log import Log
 from pycaching.log import Type as LogType
 from pycaching.trackable import Trackable
+from pycaching.util import deprecated
 
 
 class SortOrder(enum.Enum):
@@ -350,6 +351,7 @@ class Geocaching(object):
 
             return bs4.BeautifulSoup(res["HtmlString"].strip(), "html.parser"), None
 
+    @deprecated
     def search_quick(self, area):
         """Search for caches in a specified :class:`.Rectangle` area.
 

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -6,7 +6,6 @@ import json
 import logging
 import re
 import subprocess
-import warnings
 from os import path
 from typing import Optional, Union
 from urllib.parse import parse_qs, urljoin, urlparse

--- a/test/cassettes/geocaching_matchload.json
+++ b/test/cassettes/geocaching_matchload.json
@@ -1,4 +1,0 @@
-{
-  "http_interactions": [],
-  "recorded_with": "betamax/0.8.1"
-}

--- a/test/cassettes/geocaching_quick_normal.json
+++ b/test/cassettes/geocaching_quick_normal.json
@@ -1,4 +1,0 @@
-{
-  "http_interactions": [],
-  "recorded_with": "betamax/0.8.1"
-}

--- a/test/cassettes/geocaching_quick_search.json
+++ b/test/cassettes/geocaching_quick_search.json
@@ -1,0 +1,86 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2023-03-25T19:01:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "gspkauth=<AUTH COOKIE>; Culture=en-US; __RequestVerificationToken=<AUTH COOKIE>"
+          ],
+          "User-Agent": [
+            "python-requests/2.28.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.4&take=200&asc=true&skip=0&sort=datelastvisited"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6pWKkotLs0pKVayiq5WykxRsjIzMzayNDDQUcpLzE1VslIK8FVQNjFV8M0vLlH4ML+nU0lHKTk/BSTj7mzu7RLuChQoKErNzSzN9c/LqVSySkvMKU7VUUpLLMsvyixJDcjPzAMZb2Kpo5Semp+cmJyRGlJZADTAAmRSXkliZl5qEVwkJTMtLTMZ6CKgScZ6QGeUpBYVAZUoWZmCeGDtwSWJJaVAI4H8AqCzUlOc8/OLUjLzEktSgaLVSjmJJZklpSA3mljqmRsbmFgY6yjl5OelQ0UNjfWMLQzNTWuB1qUC7c8pDi3KAXpIH+Y+fYTXMhKL3VPzS/JLi+A+K8hJTE5NcQHaBtRjZGBooWtgrGtoGGJgYAVGQF355UA/gZwCDaqAIBf3AC8XoExpcWoRNGSrUlIzErOUgK7ISSwuccsvzUMYamSka2ika2ASYmgEN7SkKDE5OzEpJ9UZqLQE7P2i1PTMfGDYKAXkVKUe7SjOPrxXIbsIaCgoaIGKioChqORclZqckZkIFEssKSnKTCoFBxM0uo1M4DEdnpGampOckZhZpJCYnJxaXJwJtAuoK7PYsaAgJzMZZDU0EGp1ILoN4Zpd8tOL0dValRSVIpQC4wCq1rEMGOYgFQpGJvrmeHUZG8F1OWUmVybnAJ2OT70ZwjshRampCsk5mblJmXnpCkWphaWZRakp6LpRbYNrdobpS09NLCKgORam3cTS0sLYHBEmaZk5uflliQq5mcUliQq6Cr7AtKWQqBCcmpRaXAKSyFYoSUwqzclURM5UpmFeBgFEZipjU0KZChjD+DKVEamZCmggOFOZGhijZyo9Y0sjC2NjfLkK5jcicpWproGZrpEx/lxlEuhqZIqaq3JKsysz8vOqMrPRcxbEYCNjXQMjXSMDfDkLGIX0zllAZSg5ywyuOSg1OT83NzUvJTVFIS2/SCE7MwU9D6DlNPRMia6U1EyJrotQpkRXD0opUPW+wEgvQteC7n+wHkToBZYmovsYXTUoH0BV+6el6RblJ6YolKVmZKLbg0UnMMPA8nxibkEaMJsT0GEErMhgRUxqTmoBMLGlKuQBi4mkSnSNqKGAiNLgvPzy3PykTHTXodtFqDhDL5HQtRsiOTUzORvdMvTyy9zQzMTY0BzhzJzSvORUHYWU0oxEYLmVlZqSl1+UX5WcCc4E0OLKwswiLBIogFJcgcxFL60gOQK1tAJGG3oTALW0Alf6SKUVSANaaYWzsIG5jFBhAywTDHQNTIEVLv7CxsLPPcAIKINU2ITk5yYW5+fjKWrALQM8RQ16JU5qUUNqYYGeKtELC3SlhLI9HvWmCGf5pqYA04ZCRmZ2qoKGoUJ27qOGyYYGQFoT3QTUBIxIv8GZ6XmZwGSRmFcCNgZdH1rCR+Qb5BBJLFHIy0zPKMGv2RQRJsEFqcmZiTkKJfn5Oeh5Dt3TUM0IJ7vl56egFwzoFhIqvdBDGF0nwqmg0gtUMqBbiK6NUKGHrgOawhAdgnCgaqDDihWSUhOBmRddH2rqQvgMUb9k5imUAwsEYO5C14qS2pDKroz8ojx0B6IXXmaWRuZGiODwyAe1XRRygXkRiDOzQSECL7MMzQy9g4AChJpYoEILVEWiN7HQCy30JhaomIIXWobohRahJhbQQHATy9IcVBaj91vMTS3Qm1gopR7Mb4RKPSMDA3NdA0tdQwv8pZ6RhVe4GVAGqdRLSc1KMzdFL/MghkLLPAtal3lWJojSyC81NaUYGNWgRJWXCKyy0JMKSsIi1C7Dq5lQSYtHqwlSsVJSlJ+Tk4puK7pW9EIaqBO9kEZXSqhFh64LFiaIfBqQWJSNXo6g64JlUfQKAb0UQQ8BRCESXJKamFOSgV6mouuD2oPefkS3Cl0LoYIHXSt6UWJmaGxqjigjQUMgphYKAYkFQKfmFWeDUiRiDMQrKAjUBSGmLEEfAkEvSiAiyEWJCXr7B60oAaYMYooSM0tsRYmJoZk5elGCMgYC9RqhogQyBgLsVJmiFyVovTVzy0hQ0YRUlARlJoe4BqAXJRBD0cdAaF2UgGxFL0rQ8yWppQF6jYo+dALSi56n0a0hlKfRbYBpQzTkQxKzU4sVwJV2SUZingKox5IBik50/ci2miKyUDCwAoY0uxQ0bEDNN/RmG6n5HF0f1J/o3RV0xajZ1MQS2FtBWBXl76/gWZQJ0gXPnFHOpqBBN2LyJjC0UPMmMFHgz5vgip1QNU8ob5obmxihj6SA8qaBoSHevAn1GaGsCazlzYA9EPRaHj1rBhmaRJgFomZN30xgzZgTrKCm4JaTXw5Uj55JwcZD6nv04RR6Z1L0hEJqJkXXCkthhKpsdK3oVTZIJ3r2RldKKHuj6yI1d2PXjl53o1eo6OoJ5Wl0fYhsampmYmiA1L4AJgBgHZqqAArQ1Kyk0mLUprlhQFA4kVkWffATNH6LnmXRW+ZUybLAgRL06hSUZS3Rq1O0ljnUa4TyLKRlDsxU5gTyrLNBpDtqni0rTalEz6cQI6H51Ag9n6IPe9I6n6KnFFKzAbouUrMBUCVKJWmEKB4CSpOAaoDpMjGvuABY4QHjPD8PvR2MnsahbgeOVxuaITzgXpkLHH9GTtbu4aYmhJI1bKYMPVmjtxLBCR05WYNH8dHH9ElN1sAOJ3orEdLhBA4J4k3WUK8RkawtdA1BI23oyRqtw2nmHOmNmqy9gPMlqUWZ6CkbYio0ZaOPsqHXQJSmbEIdR/T6AD2hEapL0NMXoboEXSmhTIRPF6HuH7ouQlUIunqo2wgNyuHTi96fA/kLvT+Hnjvhmg0NTU3MkDJ6aonC0X2lOfllh/cCZ+QK8nPzDq9Nzi5FybC+5u7os3CkZlj0egg9w6LXQ2RkWPR6CDQJZ4A+CQf0EEqGhXqNiAxrCZqEMzRDz7Bo9ZB3uIsHaobNLCuqLEbPrhAzQdnVUNcIfYCI2tmVUEWEnmCQcwOhfI6umVA+R9eLbjGhfI6ulFA+R9eFXlkCNRGqLNG1Eyom0HWh5D8zSwtzC0T7ETo0WwIaRc47vFIBnAvzy9BGaM0jQX6hNPuhD9DCsh96M5Cs7GdhaIHecwNmPzNj9GYg+gAtxGuEsh+4GQiqLw3Rsx+pA7T0zn/QWEcv7dH7XehJBpHQCOUhdK2E8hC6UkJ5CF0XqXkIXTupeQhdF6GqFl09od4auj70ahY1SNCrWfRsDtNsYWZqbGGBCB9TQz3w/MvRmcDUs1Dh6MLs/ByUoVPLEItwL6AAoUwOnoZBz+TowzPomRy9jiU1kwMNBGdyUCpBz+JmxuhzMKhZHOYxQlkcPMYJnHk2MMafxT1cLNwigDJIWfzo3tScskQFY/RMDjUWfVQGqJnamRyS0AhVsujJBV4nECod0LWSWjqgayVUOqArJVQ6oOsitXRA106odMCnC+FScDDoF0D1pqWiBwehYgU9TFDVExoSRtdJaoGEro/QdDq6FkhoEOrREzKDUDmIHoXwcjBWR6kkvyQxR8nK0LAWEAAA//+6vc5rWisAAA==",
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Cache-Control": [
+            "max-age=60, private"
+          ],
+          "Connection": [
+            "Keep-Alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "2647"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "CorrelationGuid": [
+            "05719242-28d1-41f4-a71f-29f36eed56df"
+          ],
+          "Date": [
+            "Sat, 25 Mar 2023 19:01:13 GMT"
+          ],
+          "Set-Cookie": [
+            "jwt=<AUTH COOKIE>; expires=Sat, 25 Mar 2023 20:00:13 GMT; domain=.geocaching.com; path=/; secure; httponly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubDomains"
+          ],
+          "Vary": [
+            "Accept-Encoding"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ],
+          "X-XSS-Protection": [
+            "1"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.geocaching.com/api/proxy/web/search?box=49.74%2C13.38%2C49.73%2C13.4&take=200&asc=true&skip=0&sort=datelastvisited"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/test/test_geocaching.py
+++ b/test/test_geocaching.py
@@ -39,55 +39,15 @@ class TestMethods(LoggedInTest):
                 caches = list(self.gc.search(Point(49.733867, 13.397091), 100))
             self.assertNotEqual(caches[0], caches[50])
 
-    @unittest.expectedFailure
     def test_search_quick(self):
         """Perform quick search and check found caches"""
-        # at time of writing, there were exactly 16 caches in this area + one PM only
-        expected_cache_num = 16
-        tolerance = 7
         rect = Rectangle(Point(49.73, 13.38), Point(49.74, 13.40))
 
-        with self.subTest("normal"):
-            with self.recorder.use_cassette("geocaching_quick_normal"):
-                # Once this feature is fixed, the corresponding cassette will have to be deleted
-                # and re-recorded.
-                res = [c.wp for c in self.gc.search_quick(rect)]
-            for wp in ["GC41FJC", "GC17E8Y", "GC383XN"]:
-                self.assertIn(wp, res)
-            # but 108 caches larger tile
-            self.assertLess(len(res), 130)
-            self.assertGreater(len(res), 90)
-
-        with self.subTest("strict handling of cache coordinates"):
-            with self.recorder.use_cassette("geocaching_quick_strictness"):
-                res = list(self.gc.search_quick(rect, strict=True))
-            self.assertLess(len(res), expected_cache_num + tolerance)
-            self.assertGreater(len(res), expected_cache_num - tolerance)
-
-        with self.subTest("larger zoom - more precise"):
-            with self.recorder.use_cassette("geocaching_quick_zoom"):
-                res1 = list(self.gc.search_quick(rect, strict=True, zoom=15))
-                res2 = list(self.gc.search_quick(rect, strict=True, zoom=14))
-            for res in res1, res2:
-                self.assertLess(len(res), expected_cache_num + tolerance)
-                self.assertGreater(len(res), expected_cache_num - tolerance)
-            for c1, c2 in itertools.product(res1, res2):
-                self.assertLess(c1.location.precision, c2.location.precision)
-
-    @unittest.expectedFailure
-    def test_search_quick_match_load(self):
-        """Test if quick search results matches exact cache locations."""
-        rect = Rectangle(Point(49.73, 13.38), Point(49.74, 13.39))
-        with self.recorder.use_cassette("geocaching_matchload"):
-            # at commit time, this test is an allowed failure. Once this feature is fixed, the
-            # corresponding cassette will have to be deleted and re-recorded.
-            caches = list(self.gc.search_quick(rect, strict=True, zoom=15))
-            for cache in caches:
-                try:
-                    cache.load()
-                    self.assertIn(cache.location, rect)
-                except PMOnlyException:
-                    pass
+        with self.recorder.use_cassette("geocaching_quick_search"):
+            res = [c.wp for c in self.gc.search_quick(rect)]
+        for wp in ["GC11PRW", "GC161KR", "GC167Y7"]:
+            self.assertIn(wp, res)
+        self.assertEqual(len(res), 11)
 
     def test__try_getting_cache_from_guid(self):
         # get "normal" cache from guidpage

--- a/test/test_geocaching.py
+++ b/test/test_geocaching.py
@@ -1,5 +1,3 @@
-import itertools
-import unittest
 from unittest.mock import patch
 
 from geopy.distance import great_circle


### PR DESCRIPTION
As discussed in https://github.com/tomasbedrich/pycaching/pull/151, I've deprecated the `Geocaching.search_quick()` method. I've added a temporary solution with the use of `Geocaching.search_rect()`.

I've also updated the `README.rst` to reference `Geocaching.search_rect()` for searching for caches in an area.

And last but not least, I've updated the tests for this method.

---

Related issue:
- Fixes https://github.com/tomasbedrich/pycaching/issues/153