### PR TITLE
Add an error case for CAPTCHA problems

### DIFF
--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -155,6 +155,10 @@ class Geocaching(object):
             return
         else:
             self.logout()
+
+            if after_login_page.find("div", class_="g-recaptcha"):
+                raise LoginFailedException("CAPTCHA is required to login to the site.")
+
             raise LoginFailedException("Cannot login to the site (probably wrong username or password).")
 
     def _load_credentials(self, username=None):


### PR DESCRIPTION
This PR adds an error case to handle the situation where the login page requires a CAPTCHA. If this occurs, the `errors.LoginFailedException` is raised with an appropriate message (`CAPTCHA is required to login to the site.`).

---

When a login needs CAPTCHA, there is a present `div` element with class `g-recaptcha`. So by simply checking for the presence of the mentioned element, we could distinguish between wrong login credentials and problems with CAPTCHA.

---

Related issue:
- https://github.com/tomasbedrich/pycaching/issues/157