### PR TITLE
Adding html_description attribute to the Cache object

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -829,7 +829,7 @@ class Cache(object):
 
         self.summary = root.find(id="ctl00_ContentBody_ShortDescription").text
         self.description = root.find(id="ctl00_ContentBody_LongDescription").text
-        self.descriptin_html = root.find(id="ctl00_ContentBody_LongDescription")
+        self.description_html = root.find(id="ctl00_ContentBody_LongDescription")
         
         self.hint = rot13(root.find(id="div_hint").get_text(separator="\n"))
 
@@ -955,7 +955,7 @@ class Cache(object):
 
         self.description = content.find("h2", string="Long Description").find_next("div").text
 
-        self.descriptin_html = content.find("h2", string="Long Description").find_next("div")
+        self.description_html = content.find("h2", string="Long Description").find_next("div")
 
         self.hint = content.find(id="uxEncryptedHint").get_text(separator="\n")
 

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -223,6 +223,7 @@ class Cache(object):
             "attributes",
             "summary",
             "description",
+            "html_description",
             "hint",
             "favorites",
             "pm_only",
@@ -616,6 +617,20 @@ class Cache(object):
 
     @property
     @lazy_loaded
+    def html_description(self):
+        """The cache long description in raw HTML.
+
+        :type: :class:`str`
+        """
+        return self._description
+
+    @description.setter
+    def html_description(self, description):
+        description = str(description).strip()
+        self._html_description = description
+
+    @property
+    @lazy_loaded
     def hint(self):
         """The cache hint.
 
@@ -813,7 +828,8 @@ class Cache(object):
 
         self.summary = root.find(id="ctl00_ContentBody_ShortDescription").text
         self.description = root.find(id="ctl00_ContentBody_LongDescription").text
-
+        self.html_description = root.find(id="ctl00_ContentBody_LongDescription")
+        
         self.hint = rot13(root.find(id="div_hint").get_text(separator="\n"))
 
         favorites = root.find("span", "favorite-value")
@@ -937,6 +953,8 @@ class Cache(object):
         self.summary = content.find("h2", string="Short Description").find_next("div").text
 
         self.description = content.find("h2", string="Long Description").find_next("div").text
+
+        self.html_description = content.find("h2", string="Long Description").find_next("div")
 
         self.hint = content.find(id="uxEncryptedHint").get_text(separator="\n")
 

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -1022,7 +1022,7 @@ class Cache(object):
         if not element:
             raise errors.ValueError("Log counts could not be found.")
 
-        # Text gives numbers and verbose s of the current values as well as an
+        # Text gives numbers and verbose of the current values as well as an
         # introductory text. So we have to perform number checks for each element and only keep
         # the numbers.
         # The values might contain thousand separators, which we have to remove before converting

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -1022,7 +1022,7 @@ class Cache(object):
         if not element:
             raise errors.ValueError("Log counts could not be found.")
 
-        # Text gives numbers and verbose of the current values as well as an
+        # Text gives numbers and verbose descriptions of the current values as well as an
         # introductory text. So we have to perform number checks for each element and only keep
         # the numbers.
         # The values might contain thousand separators, which we have to remove before converting

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -155,6 +155,7 @@ class Cache(object):
             del cache_info["attributes"]["attribute"]
         cache_info["summary"] = content.find("h2", string="Short Description").find_next("div").text
         cache_info["description"] = content.find("h2", string="Long Description").find_next("div").text
+        cache_info["html_description"] = content.find("h2", string="Long Description").find_next("div")
         hint = content.find(id="uxEncryptedHint")
         cache_info["hint"] = hint.get_text(separator="\n") if hint else None
         cache_info["waypoints"] = Waypoint.from_html(content, table_id="Waypoints")

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -830,7 +830,7 @@ class Cache(object):
         self.summary = root.find(id="ctl00_ContentBody_ShortDescription").text
         self.description = root.find(id="ctl00_ContentBody_LongDescription").text
         self.description_html = root.find(id="ctl00_ContentBody_LongDescription")
-        
+
         self.hint = rot13(root.find(id="div_hint").get_text(separator="\n"))
 
         favorites = root.find("span", "favorite-value")
@@ -1098,7 +1098,6 @@ class Cache(object):
                 return
 
             for log_data in logbook_page:
-
                 limit -= 1  # handle limit
                 if limit < 0:
                     return
@@ -1140,7 +1139,6 @@ class Cache(object):
         names = [re.split(r"[\<\>]", str(link))[2] for link in links if "track" in link.get("href")]
 
         for name, url in zip(names, urls):
-
             limit -= 1  # handle limit
             if limit < 0:
                 return

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -154,8 +154,9 @@ class Cache(object):
         if "attribute" in cache_info["attributes"]:  # 'blank' attribute
             del cache_info["attributes"]["attribute"]
         cache_info["summary"] = content.find("h2", string="Short Description").find_next("div").text
-        cache_info["description"] = content.find("h2", string="Long Description").find_next("div").text
-        cache_info["description_html"] = str(content.find("h2", string="Long Description").find_next("div"))
+        raw-description = content.find("h2", string="Long Description").find_next("div")
+        cache_info["description"] = long-description.text
+        cache_info["description_html"] = str(long-description)
         hint = content.find(id="uxEncryptedHint")
         cache_info["hint"] = hint.get_text(separator="\n") if hint else None
         cache_info["waypoints"] = Waypoint.from_html(content, table_id="Waypoints")

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -155,8 +155,8 @@ class Cache(object):
             del cache_info["attributes"]["attribute"]
         cache_info["summary"] = content.find("h2", string="Short Description").find_next("div").text
         raw-description = content.find("h2", string="Long Description").find_next("div")
-        cache_info["description"] = long-description.text
-        cache_info["description_html"] = str(long-description)
+        cache_info["description"] = raw-description.text
+        cache_info["description_html"] = str(raw-description)
         hint = content.find(id="uxEncryptedHint")
         cache_info["hint"] = hint.get_text(separator="\n") if hint else None
         cache_info["waypoints"] = Waypoint.from_html(content, table_id="Waypoints")

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -617,7 +617,7 @@ class Cache(object):
 
     @property
     @lazy_loaded
-    def descriptin_html(self):
+    def description_html(self):
         """The cache long description in raw HTML.
 
         :type: :class:`str`
@@ -625,9 +625,9 @@ class Cache(object):
         return self._description
 
     @description.setter
-    def descriptin_html(self, description):
+    def description_html(self, description):
         description = str(description).strip()
-        self._descriptin_html = description
+        self._description_html = description
 
     @property
     @lazy_loaded

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -155,7 +155,7 @@ class Cache(object):
             del cache_info["attributes"]["attribute"]
         cache_info["summary"] = content.find("h2", string="Short Description").find_next("div").text
         cache_info["description"] = content.find("h2", string="Long Description").find_next("div").text
-        cache_info["html_description"] = content.find("h2", string="Long Description").find_next("div")
+        cache_info["description_html"] = str(content.find("h2", string="Long Description").find_next("div"))
         hint = content.find(id="uxEncryptedHint")
         cache_info["hint"] = hint.get_text(separator="\n") if hint else None
         cache_info["waypoints"] = Waypoint.from_html(content, table_id="Waypoints")
@@ -223,7 +223,7 @@ class Cache(object):
             "attributes",
             "summary",
             "description",
-            "html_description",
+            "description_html",
             "hint",
             "favorites",
             "pm_only",
@@ -617,7 +617,7 @@ class Cache(object):
 
     @property
     @lazy_loaded
-    def html_description(self):
+    def descriptin_html(self):
         """The cache long description in raw HTML.
 
         :type: :class:`str`
@@ -625,9 +625,9 @@ class Cache(object):
         return self._description
 
     @description.setter
-    def html_description(self, description):
+    def descriptin_html(self, description):
         description = str(description).strip()
-        self._html_description = description
+        self._descriptin_html = description
 
     @property
     @lazy_loaded
@@ -828,7 +828,7 @@ class Cache(object):
 
         self.summary = root.find(id="ctl00_ContentBody_ShortDescription").text
         self.description = root.find(id="ctl00_ContentBody_LongDescription").text
-        self.html_description = root.find(id="ctl00_ContentBody_LongDescription")
+        self.descriptin_html = root.find(id="ctl00_ContentBody_LongDescription")
         
         self.hint = rot13(root.find(id="div_hint").get_text(separator="\n"))
 
@@ -954,7 +954,7 @@ class Cache(object):
 
         self.description = content.find("h2", string="Long Description").find_next("div").text
 
-        self.html_description = content.find("h2", string="Long Description").find_next("div")
+        self.descriptin_html = content.find("h2", string="Long Description").find_next("div")
 
         self.hint = content.find(id="uxEncryptedHint").get_text(separator="\n")
 

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -625,7 +625,7 @@ class Cache(object):
         """
         return self._description
 
-    @description.setter
+    @description_html.setter
     def description_html(self, description):
         description = str(description).strip()
         self._description_html = description

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -153,7 +153,7 @@ class Cache(object):
         cache_info["attributes"] = {attr_name: attr_setting == "yes" for attr_name, _, attr_setting in attributes}
         if "attribute" in cache_info["attributes"]:  # 'blank' attribute
             del cache_info["attributes"]["attribute"]
-        cache_info["summary"] = content.find("h2", string="Short ").find_next("div").text
+        cache_info["summary"] = content.find("h2", string="Short Description").find_next("div").text
         raw_description = content.find("h2", string="Long Description").find_next("div")
         cache_info["description"] = raw_description.text
         cache_info["description_html"] = str(raw_description)

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -623,7 +623,7 @@ class Cache(object):
 
         :type: :class:`str`
         """
-        return self._description
+        return self._description_html
 
     @description_html.setter
     def description_html(self, description):

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -154,9 +154,9 @@ class Cache(object):
         if "attribute" in cache_info["attributes"]:  # 'blank' attribute
             del cache_info["attributes"]["attribute"]
         cache_info["summary"] = content.find("h2", string="Short Description").find_next("div").text
-        raw-description = content.find("h2", string="Long Description").find_next("div")
-        cache_info["description"] = raw-description.text
-        cache_info["description_html"] = str(raw-description)
+        raw_description = content.find("h2", string="Long Description").find_next("div")
+        cache_info["description"] = raw_description.text
+        cache_info["description_html"] = str(raw_description)
         hint = content.find(id="uxEncryptedHint")
         cache_info["hint"] = hint.get_text(separator="\n") if hint else None
         cache_info["waypoints"] = Waypoint.from_html(content, table_id="Waypoints")

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -956,7 +956,6 @@ class Cache(object):
 
         raw_description = content.find("h2", string="Long Description").find_next("div")
         self.description = raw_description.text
-
         self.description_html = str(raw_description)
 
         self.hint = content.find(id="uxEncryptedHint").get_text(separator="\n")

--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -153,7 +153,7 @@ class Cache(object):
         cache_info["attributes"] = {attr_name: attr_setting == "yes" for attr_name, _, attr_setting in attributes}
         if "attribute" in cache_info["attributes"]:  # 'blank' attribute
             del cache_info["attributes"]["attribute"]
-        cache_info["summary"] = content.find("h2", string="Short Description").find_next("div").text
+        cache_info["summary"] = content.find("h2", string="Short ").find_next("div").text
         raw_description = content.find("h2", string="Long Description").find_next("div")
         cache_info["description"] = raw_description.text
         cache_info["description_html"] = str(raw_description)
@@ -828,8 +828,9 @@ class Cache(object):
         }
 
         self.summary = root.find(id="ctl00_ContentBody_ShortDescription").text
-        self.description = root.find(id="ctl00_ContentBody_LongDescription").text
-        self.description_html = root.find(id="ctl00_ContentBody_LongDescription")
+        raw_description = root.find(id="ctl00_ContentBody_LongDescription")
+        self.description = raw_description.text
+        self.description_html = str(raw_description)
 
         self.hint = rot13(root.find(id="div_hint").get_text(separator="\n"))
 
@@ -953,9 +954,10 @@ class Cache(object):
 
         self.summary = content.find("h2", string="Short Description").find_next("div").text
 
-        self.description = content.find("h2", string="Long Description").find_next("div").text
+        raw_description = content.find("h2", string="Long Description").find_next("div")
+        self.description = raw_description.text
 
-        self.description_html = content.find("h2", string="Long Description").find_next("div")
+        self.description_html = str(raw_description)
 
         self.hint = content.find(id="uxEncryptedHint").get_text(separator="\n")
 
@@ -1020,7 +1022,7 @@ class Cache(object):
         if not element:
             raise errors.ValueError("Log counts could not be found.")
 
-        # Text gives numbers and verbose descriptions of the current values as well as an
+        # Text gives numbers and verbose s of the current values as well as an
         # introductory text. So we have to perform number checks for each element and only keep
         # the numbers.
         # The values might contain thousand separators, which we have to remove before converting

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -33,8 +33,8 @@ class TestProperties(unittest.TestCase):
             hidden=date(2000, 1, 1),
             attributes={"onehour": True, "kids": False, "available": True},
             summary="text",
-            description="long text",
-            description_html="<h1>some header</h1><p>some text</p>",
+            description="engelmz",
+            description_html="<b><font color="red">engelmz</font></b>",
             hint="rot13",
             favorites=0,
             pm_only=False,
@@ -188,10 +188,10 @@ class TestProperties(unittest.TestCase):
         self.assertEqual(self.c.summary, "text")
 
     def test_description(self):
-        self.assertEqual(self.c.description, "long text")
+        self.assertEqual(self.c.description, "engelmz")
 
     def test_description_html(self):
-        self.assertEqual(self.c.description_html, "<p><b>Wir haben das Luftschloss wieder saniert und haben beschlossen ihn nicht mehr zu sanieren, sollte er wieder mutwillig kaputt gemacht werden. Wen es interessiert wie der Cache funktioniert, der kann gerne eine Mail schreiben.</b></p>")
+        self.assertEqual(self.c.description_html, "<b><font color="red">engelmz</font></b>")
 
     def test_hint(self):
         self.assertEqual(self.c.hint, "rot13")
@@ -282,8 +282,8 @@ class TestMethods(LoggedInTest):
                 },
             )
             self.assertEqual(cache.summary, "Gibt es das Luftschloss wirklich?")
-            self.assertIn("Seit dem 16.", cache.description)
-            self.assertIn("<p><b>Wir haben das Luftschloss wieder saniert und haben beschlossen ihn nicht mehr zu sanieren, sollte er wieder mutwillig kaputt gemacht werden. Wen es interessiert wie der Cache funktioniert, der kann gerne eine Mail schreiben.</b></p>", cache.description_html)
+            self.assertIn("engelmz", cache.description)
+            self.assertIn("<b><font color="red">engelmz</font></b>", cache.description_html)
             self.assertEqual(cache.hint, "Das ist nicht nötig")
             self.assertGreater(cache.favorites, 350)
             self.assertEqual(len(cache.waypoints), 2)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -245,7 +245,10 @@ class TestMethods(LoggedInTest):
                 cache = Cache(self.gc, "GC4808G")
                 self.assertIn("Tuhle zprávu ti nepíšu proto, abych ti řekl, že ", cache.description)
                 self.assertIn(
-                    ';background-color:black;border:1px solid black;padding:20px;">Tuhle zprávu ti nepíšu proto, abych ti řekl, že ',
+                    (
+                        ';background-color:black;border:1px solid black;padding:20px;">'
+                        'Tuhle zprávu ti nepíšu proto, abych ti řekl, že '
+                    ),
                     cache.description_html,
                 )
 
@@ -292,11 +295,14 @@ class TestMethods(LoggedInTest):
             )
             self.assertEqual(cache.summary, "Gibt es das Luftschloss wirklich?")
             self.assertIn(
-                " funktioniert, der kann gerne eine Mail schreiben.\r\nSeit dem 16. Jahrhundert steht die Menschheit vor dem ",
+                " funktioniert, der kann gerne eine Mail schreiben.\r\nSeit dem 16. Jahrhundert steht die ",
                 cache.description,
             )
             self.assertIn(
-                " funktioniert, der kann gerne eine Mail schreiben.</b></p>\r\nSeit dem 16. Jahrhundert steht die Menschheit vor dem ",
+                (
+                    " funktioniert, der kann gerne eine Mail schreiben.</b></p>\r\n"
+                    "Seit dem 16. Jahrhundert steht die "
+                ),
                 cache.description_html,
             )
             self.assertEqual(cache.hint, "Das ist nicht nötig")

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -245,8 +245,8 @@ class TestMethods(LoggedInTest):
                 cache = Cache(self.gc, "GC4808G")
                 self.assertIn("Tuhle zprávu ti nepíšu proto, abych ti řekl, že ", cache.description)
                 self.assertIn(
-                    ';background-color:black;border:1px solid black;padding:20px;\">Tuhle zprávu ti nepíšu proto, abych ti řekl, že ',
-                    cache.description_html
+                    ';background-color:black;border:1px solid black;padding:20px;">Tuhle zprávu ti nepíšu proto, abych ti řekl, že ',
+                    cache.description_html,
                 )
 
     def test_load_quick(self):
@@ -293,11 +293,11 @@ class TestMethods(LoggedInTest):
             self.assertEqual(cache.summary, "Gibt es das Luftschloss wirklich?")
             self.assertIn(
                 " funktioniert, der kann gerne eine Mail schreiben.\r\nSeit dem 16. Jahrhundert steht die Menschheit vor dem ",
-                cache.description_html
+                cache.description,
             )
             self.assertIn(
                 " funktioniert, der kann gerne eine Mail schreiben.</b></p>\r\nSeit dem 16. Jahrhundert steht die Menschheit vor dem ",
-                cache.description_html
+                cache.description_html,
             )
             self.assertEqual(cache.hint, "Das ist nicht nötig")
             self.assertGreater(cache.favorites, 350)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -283,7 +283,7 @@ class TestMethods(LoggedInTest):
             )
             self.assertEqual(cache.summary, "Gibt es das Luftschloss wirklich?")
             self.assertIn("Seit dem 16.", cache.description)
-            self.assertIn("<h1>some header</h1><p>some text</p>", cache.description_html)
+            self.assertIn("<p><b>Wir haben das Luftschloss wieder saniert und haben beschlossen ihn nicht mehr zu sanieren, sollte er wieder mutwillig kaputt gemacht werden. Wen es interessiert wie der Cache funktioniert, der kann gerne eine Mail schreiben.</b></p>", cache.description_html)
             self.assertEqual(cache.hint, "Das ist nicht nötig")
             self.assertGreater(cache.favorites, 350)
             self.assertEqual(len(cache.waypoints), 2)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -247,7 +247,7 @@ class TestMethods(LoggedInTest):
                 self.assertIn(
                     (
                         ';background-color:black;border:1px solid black;padding:20px;">'
-                        'Tuhle zprávu ti nepíšu proto, abych ti řekl, že '
+                        "Tuhle zprávu ti nepíšu proto, abych ti řekl, že "
                     ),
                     cache.description_html,
                 )

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -240,6 +240,15 @@ class TestMethods(LoggedInTest):
                     cache = Cache(self.gc, "GC123456")
                     cache.load()
 
+        with self.subTest("description"):
+            with self.recorder.use_cassette("cache_normal_normal"):
+                cache = Cache(self.gc, "GC4808G")
+                self.assertIn("Tuhle zprávu ti nepíšu proto, abych ti řekl, že ", cache.description)
+                self.assertIn(
+                    ';background-color:black;border:1px solid black;padding:20px;\">Tuhle zprávu ti nepíšu proto, abych ti řekl, že ',
+                    cache.description_html
+                )
+
     def test_load_quick(self):
         with self.subTest("normal"):
             with self.recorder.use_cassette("cache_quick_normal"):
@@ -282,8 +291,14 @@ class TestMethods(LoggedInTest):
                 },
             )
             self.assertEqual(cache.summary, "Gibt es das Luftschloss wirklich?")
-            self.assertIn("Luftballon", cache.description)
-            self.assertIn("<b>Luftballon</b>", cache.description_html)
+            self.assertIn(
+                " funktioniert, der kann gerne eine Mail schreiben.\r\nSeit dem 16. Jahrhundert steht die Menschheit vor dem ",
+                cache.description_html
+            )
+            self.assertIn(
+                " funktioniert, der kann gerne eine Mail schreiben.</b></p>\r\nSeit dem 16. Jahrhundert steht die Menschheit vor dem ",
+                cache.description_html
+            )
             self.assertEqual(cache.hint, "Das ist nicht nötig")
             self.assertGreater(cache.favorites, 350)
             self.assertEqual(len(cache.waypoints), 2)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -191,7 +191,7 @@ class TestProperties(unittest.TestCase):
         self.assertEqual(self.c.description, "long text")
 
     def test_description_html(self):
-        self.assertEqual(self.c.description_html, "<h1>some header</h1><p>some text</p>")
+        self.assertEqual(self.c.description_html, "<p><b>Wir haben das Luftschloss wieder saniert und haben beschlossen ihn nicht mehr zu sanieren, sollte er wieder mutwillig kaputt gemacht werden. Wen es interessiert wie der Cache funktioniert, der kann gerne eine Mail schreiben.</b></p>")
 
     def test_hint(self):
         self.assertEqual(self.c.hint, "rot13")

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -165,7 +165,6 @@ class TestProperties(unittest.TestCase):
                 self.c.hidden = None
 
     def test_visited(self):
-
         with self.subTest("automatic str conversion"):
             self.c.visited = "1/30/2000"
             self.assertEqual(self.c.visited, date(2000, 1, 30))
@@ -190,7 +189,7 @@ class TestProperties(unittest.TestCase):
 
     def test_description(self):
         self.assertEqual(self.c.description, "long text")
-        
+
     def test_description_html(self):
         self.assertEqual(self.c.description_html, "<h1>some header</h1><p>some text</p>")
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -33,8 +33,8 @@ class TestProperties(unittest.TestCase):
             hidden=date(2000, 1, 1),
             attributes={"onehour": True, "kids": False, "available": True},
             summary="text",
-            description="engelmz",
-            description_html="<b><font color="red">engelmz</font></b>",
+            description="Luftballon",
+            description_html="<b>Luftballon</b>",
             hint="rot13",
             favorites=0,
             pm_only=False,
@@ -188,10 +188,10 @@ class TestProperties(unittest.TestCase):
         self.assertEqual(self.c.summary, "text")
 
     def test_description(self):
-        self.assertEqual(self.c.description, "engelmz")
+        self.assertEqual(self.c.description, "Luftballon")
 
     def test_description_html(self):
-        self.assertEqual(self.c.description_html, "<b><font color="red">engelmz</font></b>")
+        self.assertEqual(self.c.description_html, "<b>Luftballon</b>")
 
     def test_hint(self):
         self.assertEqual(self.c.hint, "rot13")
@@ -282,8 +282,8 @@ class TestMethods(LoggedInTest):
                 },
             )
             self.assertEqual(cache.summary, "Gibt es das Luftschloss wirklich?")
-            self.assertIn("engelmz", cache.description)
-            self.assertIn("<b><font color="red">engelmz</font></b>", cache.description_html)
+            self.assertIn("Luftballon", cache.description)
+            self.assertIn("<b>Luftballon</b>", cache.description_html)
             self.assertEqual(cache.hint, "Das ist nicht nötig")
             self.assertGreater(cache.favorites, 350)
             self.assertEqual(len(cache.waypoints), 2)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -34,6 +34,7 @@ class TestProperties(unittest.TestCase):
             attributes={"onehour": True, "kids": False, "available": True},
             summary="text",
             description="long text",
+            description_html="<h1>some header</h1><p>some text</p>",
             hint="rot13",
             favorites=0,
             pm_only=False,
@@ -189,6 +190,9 @@ class TestProperties(unittest.TestCase):
 
     def test_description(self):
         self.assertEqual(self.c.description, "long text")
+        
+    def test_description_html(self):
+        self.assertEqual(self.c.description_html, "<h1>some header</h1><p>some text</p>")
 
     def test_hint(self):
         self.assertEqual(self.c.hint, "rot13")

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -284,6 +284,7 @@ class TestMethods(LoggedInTest):
             )
             self.assertEqual(cache.summary, "Gibt es das Luftschloss wirklich?")
             self.assertIn("Seit dem 16.", cache.description)
+            self.assertIn("<h1>some header</h1><p>some text</p>", cache.description_html)
             self.assertEqual(cache.hint, "Das ist nicht nötig")
             self.assertGreater(cache.favorites, 350)
             self.assertEqual(len(cache.waypoints), 2)


### PR DESCRIPTION
As stated in issue #216, you cannot currently acces the raw HTML version of a description.
So, I'm working on adding a `html_description` attribute to the Cache object. I understand it may not work, but I'm semi-confident I understand Beautiful Soup well enough and added the right code. Bear with me though, as the code could definitely contain mistakes.