### PR TITLE
Update RTD configuration file structure

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,8 +4,12 @@
 version: 2
 
 # Enforce *pip*-based build to install package from *pyproject.toml* file.
+build:
+  os: ubuntu-22.04
+  tools:
+    python: 3
+
 python:
-  version: 3
   install:
     - method: pip
       path: .


### PR DESCRIPTION
While we declared to use the version 2 format for RTD, it seems like it is not valid anymore (or has never been a valid version 2 one).