### PR TITLE
RTD: fix Python version specifier

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: 3
+    python: '3'
 
 python:
   install:


### PR DESCRIPTION
The error message is strange:

```
Problem in your project's configuration. Invalid configuration option "build.tools.python": expected one of (2.7, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3, miniconda3-4.7, mambaforge-4.10, mambaforge-22.9), got 3
```

Apparently, the value needs to be a string, not a number: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python