### PR TITLE
Fix getting user logs

### DIFF
--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 from os import path
 from typing import Generator, Optional, Union
-from urllib.parse import parse_qs, urljoin, urlparse
+from urllib.parse import urljoin
 
 import bs4
 import requests
@@ -494,8 +494,8 @@ class Geocaching(object):
                 break
 
             link = row.find(class_="ImageLink")["href"]
-            guid = parse_qs(urlparse(link).query)["guid"][0]
-            current_cache = self._try_getting_cache_from_guid(guid)
+            wp = link.split("/")[4]
+            current_cache = self.get_cache(wp)
             date = row.find_all("td")[2].text.strip()
             current_cache.visited = date
 

--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -494,7 +494,11 @@ class Geocaching(object):
                 break
 
             link = row.find(class_="ImageLink")["href"]
+
+            # This line extracts a GC code from the cache URL
+            # Example: https://www.geocaching.com/geocache/GC12345 -> GC12345
             wp = link.split("/")[4]
+
             current_cache = self.get_cache(wp)
             date = row.find_all("td")[2].text.strip()
             current_cache.visited = date


### PR DESCRIPTION
Due to changes on the Geocaching website, iterating `my_logs()` raises an exception due to a missing query argument "guid". This is caused by an upstream change at https://www.geocaching.com/my/logs.aspx, where the format of the URL that this library uses was changed to "https://www.geocaching.com/geocache/[WP]".

This PR modifies the `my_logs()` method to use WP to find the geocache details instead of guid, which fixes the problem.