### PR TITLE
Add support for archive log type "6"

### DIFF
--- a/pycaching/log.py
+++ b/pycaching/log.py
@@ -143,6 +143,9 @@ class Type(enum.Enum):
         elif filename == "68":
             # 2 different IDs for post_reviewer_note
             return cls.post_reviewer_note
+        elif filename == "6":
+            # 2 different IDs for archive
+            return cls.archive
         elif filename == "1":
             # 2 different IDs for unarchive
             return cls.unarchive

--- a/test/test_log.py
+++ b/test/test_log.py
@@ -43,11 +43,13 @@ class TestType(unittest.TestCase):
     def test_from_filename(self):
         with self.subTest("valid types"):
             self.assertEqual(Type.found_it, Type.from_filename("2"))
+            self.assertEqual(Type.archive, Type.from_filename("5"))
             self.assertEqual(Type.visit, Type.from_filename("75"))
 
         with self.subTest("special valid types"):
             self.assertEqual(Type.visit, Type.from_filename("1001"))
             self.assertEqual(Type.publish_listing, Type.from_filename("1003"))
+            self.assertEqual(Type.archive, Type.from_filename("6"))
             self.assertEqual(Type.unarchive, Type.from_filename("1"))
 
         with self.subTest("invalid type"):


### PR DESCRIPTION
Most caches use an archive log type of "5", but some caches use an archive type of "6". Retain support for type "5" and add support for type "6".