### PR TITLE
Update parsing to reflect changes on the Geocaching website

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -974,7 +974,7 @@ class Cache(object):
         :param bs4.BeautifulSoup soup: Parsed html document of the cache details page.
         """
         lbl_find_counts = soup.find("span", {"id": "ctl00_ContentBody_lblFindCounts"})
-        log_totals = lbl_find_counts.find("ul", "LogTotals")
+        log_totals = lbl_find_counts.find("ul", {"aria-labelledby": "LoggedVisits"})
 
         # Text gives numbers separated by a lot of spaces, splitting retrieves the numbers.
         # The values might contain thousand separators, which we have to remove before converting


### PR DESCRIPTION
Geocaching changed structure of their page a bit on `2025-01-11`

**From:**
```html
<span id="ctl00_ContentBody_lblFindCounts">
    <ul class="LogTotals" aria-labelledby="LoggedVisits">
        <li>
            <img src="/images/logtypes/2.png" alt="Found it" title="Found it" /> 60
        </li>
```

**To:**
```html
<span id="ctl00_ContentBody_lblFindCounts">
    <ul class="flex p-0 gap-[1rem] list-none" aria-labelledby="LoggedVisits">
        <li class="flex items-center justify-center gap-1">
            <img height="16" width="16" src="/images/logtypes/2.png" alt="Found it" title="Found it"> 60
        </li>
```

---

Fixes #239