### PR TITLE
Fix regex pattern for extracting username

### DIFF
--- a/pycaching/geocaching.py
+++ b/pycaching/geocaching.py
@@ -273,7 +273,7 @@ class Geocaching(object):
 
         logging.debug("Checking for already logged user.")
         js_content = "\n".join(login_page.find_all(string=lambda i: isinstance(i, Script)))
-        m = re.search(r'"username":\s*"(.*)"', js_content)
+        m = re.search(r'"username"\s*:\s*"([^"]+)"', js_content)
         return m.group(1) if m else None
 
     def search(


### PR DESCRIPTION
The JSON from which we were loading the username has changed its format and it contains now a bit more data (which would incorrectly be a part of the username), refining the regex ensures that just the username of user is now captured